### PR TITLE
自動でeslintでフォーマットするように設定を変更

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,5 +3,10 @@
     "eslint.lintTask.enable": true,
     "editor.formatOnSave": true,
     "files.insertFinalNewline": true,
-    "files.trimTrailingWhitespace": true
+    "files.trimTrailingWhitespace": true,
+    "typescript.format.enable": false,
+    "javascript.format.enable": false,
+    "editor.codeActionsOnSave": {
+        "source.fixAll.eslint": true
+    }
 }


### PR DESCRIPTION
- issue:

## 🔧 修正点

- https://github.com/team-ful/noratomo/pull/54 でVSCodeのワークスペース設定を追加したが設定が不十分であった
  - ファイル保存時にESLint拡張がフォーマットを実行してくれることを望んでいたが実行されなかった
  - そのため、保存時に自動的に実行するように設定を追加した

## ✅ 自己チェック

- [x] 動作確認ができているか
- [x] 新しく追加したメソッドにユニットテストを追加しているか
- [x] 静的解析、テストは成功しているか
- [x] `Files changed`を自分で確認してミスがないか

## 📸 スクリーンショット（オプション）

## ⚠️ レビュー時に注意して欲しいこと（オプション）

## 🗣️ 補足など（オプション）
