### PR TITLE
mysql-bricksの依存パッケージに関する脆弱性を対処

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
         "cookie": "^0.5.0",
         "framer-motion": "^6",
         "jsonwebtoken": "^8.5.1",
-        "mysql-bricks": "^1.1.1",
+        "mysql-bricks": "git+https://github.com/cateiru/mysql-bricks.git",
         "mysql2": "^2.3.3",
         "next": "12.1.5",
         "nprogress": "^0.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5524,12 +5524,11 @@ mute-stream@0.0.8:
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.8.tgz#1630c42b2251ff81e2a283de96a5497ea92e5e0d"
   integrity sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==
 
-mysql-bricks@^1.1.1:
+"mysql-bricks@git+https://github.com/cateiru/mysql-bricks.git":
   version "1.1.1"
-  resolved "https://registry.yarnpkg.com/mysql-bricks/-/mysql-bricks-1.1.1.tgz#6346463719f02b41ab045ff5823926d3a5a6d8b4"
-  integrity sha512-EpyNJ+lylR1KvyvTVhsswFgxcm7Ys3yIe7vyj0eCFSLpM1aCrKUBTvhm1ZuH9yYcL4hOpmu5S2X+vxfYcqr3Lw==
+  resolved "git+https://github.com/cateiru/mysql-bricks.git#d981523863c428145fc5e4976e53fb0aca0a3a39"
   dependencies:
-    sql-bricks "^2.0.3"
+    sql-bricks "^3.0.0"
 
 mysql2@^2.3.3:
   version "2.3.3"
@@ -6526,13 +6525,6 @@ sprintf-js@~1.0.2:
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
   integrity sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=
 
-sql-bricks@^2.0.3:
-  version "2.0.5"
-  resolved "https://registry.yarnpkg.com/sql-bricks/-/sql-bricks-2.0.5.tgz#96db7c9044cb07811f61218737a9761344156962"
-  integrity sha512-Q9qpODBZPMaPb+bjlmFYKMNk/6zpXSv1VNjJmGd9LvoqXwxd8TmE39s79wzrgAfw2lzohr4eNEpWRhHT5UYAfQ==
-  dependencies:
-    underscore "1.4.x"
-
 sql-bricks@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/sql-bricks/-/sql-bricks-3.0.0.tgz#4628bfc80579454529957c1ce9b941a42de95b4e"
@@ -6920,11 +6912,6 @@ unbox-primitive@^1.0.2:
     has-bigints "^1.0.2"
     has-symbols "^1.0.3"
     which-boxed-primitive "^1.0.2"
-
-underscore@1.4.x:
-  version "1.4.4"
-  resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.4.4.tgz#61a6a32010622afa07963bf325203cf12239d604"
-  integrity sha1-YaajIBBiKvoHljvzJSA88SI51gQ=
 
 unicode-canonical-property-names-ecmascript@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
- issue:

## 🔧 修正点

`mysql-bricks`は、`sql-bricks`のv2を使用している。しかし、`sql-bricks`のv2は`underscore`というユーティリティ系ライブラリを使用しておりそのライブラリの依存しているバージョンがCVE-2021-23358の脆弱性を含んでいる。

そのため、`mysql-bricks`の依存している`sql-bricks`をv3に上げるためにPRを送った。

> https://github.com/tamarzil/mysql-bricks/pull/2

まだ、レビューは貰えていないが応急処置として自分がforkして修正したブランチは対応されているためgit経由でそのパッケージを入れる。

TODO: PRがマージされたら移行する。

ref. https://github.com/team-ful/noratomo/security/dependabot/1

## ✅ 自己チェック

- [x] 動作確認ができているか
- [x] 新しく追加したメソッドにユニットテストを追加しているか
- [x] 静的解析、テストは成功しているか
- [x] `Files changed`を自分で確認してミスがないか

## 📸 スクリーンショット（オプション）

## ⚠️ レビュー時に注意して欲しいこと（オプション）

## 🗣️ 補足など（オプション）
