### PR TITLE
【管理者限定】野良認証を追加、削除、修正、取得できるようにするAPI

### DIFF
--- a/pages/api/admin/nora_question.ts
+++ b/pages/api/admin/nora_question.ts
@@ -1,0 +1,11 @@
+import {get, post, put, _delete} from '../../../src/admin/noraQuestion';
+import {switchMethod} from '../../../src/base/switchMethod';
+
+// 野良認証の問題を作成、修正、削除をするメソッド
+// * 管理者のみ
+export default switchMethod({
+  GET: get,
+  POST: post,
+  PUT: put,
+  DELETE: _delete,
+});

--- a/pages/api/admin/nora_question.ts
+++ b/pages/api/admin/nora_question.ts
@@ -3,7 +3,7 @@ import {switchMethod} from '../../../src/base/switchMethod';
 
 // 野良認証の問題を作成、修正、削除をするメソッド
 // * 管理者のみ
-export default switchMethod({
+export default switchMethod<unknown>({
   GET: get,
   POST: post,
   PUT: put,

--- a/src/admin/noraQuestion/delete.ts
+++ b/src/admin/noraQuestion/delete.ts
@@ -1,0 +1,34 @@
+import {ApiError} from 'next/dist/server/api-utils';
+import AuthedBase from '../../base/authedBase';
+import {authHandlerWrapper} from '../../base/handlerWrapper';
+import {deleteNoraQuestionByID} from '../../services/noraQuestion';
+
+/**
+ * 野良認証の問題を削除する
+ * 管理者のみ
+ *
+ * @param {AuthedBase} base - base
+ */
+async function handler(base: AuthedBase<void>) {
+  // 管理者以外は403
+  base.adminOnly();
+
+  const _id = base.getQuery('id');
+
+  if (typeof _id === 'undefined') {
+    throw new ApiError(400, 'id require');
+  }
+
+  let id = NaN;
+  try {
+    id = parseInt(_id);
+  } catch (e) {
+    if (e instanceof Error) {
+      throw new ApiError(400, 'id is not number');
+    }
+  }
+
+  await deleteNoraQuestionByID(await base.db(), id);
+}
+
+export default authHandlerWrapper(handler);

--- a/src/admin/noraQuestion/get.ts
+++ b/src/admin/noraQuestion/get.ts
@@ -1,0 +1,38 @@
+import {ApiError} from 'next/dist/server/api-utils';
+import AuthedBase from '../../base/authedBase';
+import {authHandlerWrapper} from '../../base/handlerWrapper';
+import {NoraQuestionModel} from '../../models/noraQuestion';
+import {findAllNoraQuestion} from '../../services/noraQuestion';
+
+/**
+ * 野良認証の問題を返す
+ * `?limit`を指定することでその件数文取得可能
+ * 管理者のみ
+ *
+ * @param {AuthedBase} base - base
+ */
+async function handler(base: AuthedBase<NoraQuestionModel[]>) {
+  // 管理者以外は403
+  base.adminOnly();
+
+  const _limit = base.getQuery('limit');
+  let limit;
+  if (_limit) {
+    try {
+      limit = parseInt(_limit);
+    } catch (e) {
+      if (e instanceof Error) {
+        // パースに失敗したら400を返す
+        throw new ApiError(400, e.message);
+      }
+    }
+  }
+
+  const questions = await findAllNoraQuestion(await base.db(), limit);
+
+  const qJson = questions.map(v => v.model);
+
+  base.sendJson(qJson);
+}
+
+export default authHandlerWrapper(handler);

--- a/src/admin/noraQuestion/index.ts
+++ b/src/admin/noraQuestion/index.ts
@@ -1,0 +1,6 @@
+import _delete from './delete';
+import get from './get';
+import post from './post';
+import put from './put';
+
+export {get, post, put, _delete};

--- a/src/admin/noraQuestion/post.ts
+++ b/src/admin/noraQuestion/post.ts
@@ -1,0 +1,60 @@
+import {ApiError} from 'next/dist/server/api-utils';
+import AuthedBase from '../../base/authedBase';
+import {authHandlerWrapper} from '../../base/handlerWrapper';
+import {NoraQuestionModel} from '../../models/noraQuestion';
+import {createNoraQuestion} from '../../services/noraQuestion';
+
+interface NoraQuestion {
+  // 問題のタイトル
+  question_title: string;
+
+  // 答えの選択肢
+  answers: string[];
+
+  // 答えの回答インデックス
+  current_answer_index: number;
+
+  // この問題の重み
+  score: number;
+}
+
+/**
+ * 野良認証の問題を新規追加する
+ * 管理者のみ
+ *
+ * @param {AuthedBase} base - base
+ */
+async function handler(base: AuthedBase<NoraQuestionModel>) {
+  // 管理者以外は403
+  base.adminOnly();
+
+  const question = base.getPostJson<NoraQuestion>();
+
+  if (
+    !(
+      question.answers &&
+      typeof question.current_answer_index === 'number' &&
+      typeof question.question_title === 'string' &&
+      typeof question.score === 'number'
+    )
+  ) {
+    throw new ApiError(400, 'Incorrect json');
+  }
+
+  const insertedQuestion = await createNoraQuestion(
+    await base.db(),
+    question.question_title,
+    question.answers.map((v, i) => {
+      return {
+        index: i,
+        answerText: v,
+      };
+    }),
+    question.current_answer_index,
+    question.score
+  );
+
+  base.sendJson(insertedQuestion.model);
+}
+
+export default authHandlerWrapper(handler);

--- a/src/admin/noraQuestion/put.ts
+++ b/src/admin/noraQuestion/put.ts
@@ -1,0 +1,62 @@
+import {ApiError} from 'next/dist/server/api-utils';
+import AuthedBase from '../../base/authedBase';
+import {authHandlerWrapper} from '../../base/handlerWrapper';
+import {
+  updateNoraQuestionByID,
+  UpdateNoraQuestion,
+} from '../../services/noraQuestion';
+
+interface NoraQuestion {
+  id: number;
+
+  // 問題のタイトル
+  question_title?: string;
+
+  // 答えの選択肢
+  answers?: string[];
+
+  // 答えの回答インデックス
+  current_answer_index?: number;
+
+  // この問題の重み
+  score?: number;
+}
+
+/**
+ * 野良認証の問題を更新する
+ * 管理者のみ
+ *
+ * @param {AuthedBase} base - base
+ */
+async function handler(base: AuthedBase<void>) {
+  // 管理者以外は403
+  base.adminOnly();
+
+  const question = base.getPostJson<NoraQuestion>();
+
+  if (typeof question.id !== 'number') {
+    throw new ApiError(400, 'Incorrect json');
+  }
+
+  const q: UpdateNoraQuestion = {};
+
+  if (question.question_title) {
+    q['question_title'] = question.question_title;
+  }
+  if (question.answers) {
+    q['answers'] = question.answers.map((v, i) => ({
+      index: i,
+      answerText: v,
+    }));
+  }
+  if (question.current_answer_index) {
+    q['current_answer_index'] = question.current_answer_index;
+  }
+  if (question.score) {
+    q['score'] = question.score;
+  }
+
+  await updateNoraQuestionByID(await base.db(), question.id, q);
+}
+
+export default authHandlerWrapper(handler);

--- a/src/base/authedBase.ts
+++ b/src/base/authedBase.ts
@@ -70,6 +70,12 @@ class AuthedBase<T> extends Base<T> {
       join_date: u.join_date,
     };
   }
+
+  public adminOnly() {
+    if (this._user && !this._user.is_admin) {
+      throw new ApiError(403, 'no administrator');
+    }
+  }
 }
 
 export default AuthedBase;

--- a/src/models/noraQuestion.ts
+++ b/src/models/noraQuestion.ts
@@ -59,4 +59,14 @@ export class NoraQuestion implements NoraQuestionModel {
       answerLen > this.current_answer_index && this.current_answer_index >= 0
     );
   }
+
+  get model(): NoraQuestionModel {
+    return {
+      id: this.id,
+      question_title: this.question_title,
+      answers: this.answers,
+      current_answer_index: this.current_answer_index,
+      score: this.score,
+    };
+  }
 }

--- a/src/models/noraQuestion.ts
+++ b/src/models/noraQuestion.ts
@@ -56,7 +56,7 @@ export class NoraQuestion implements NoraQuestionModel {
     }
 
     return (
-      answerLen >= this.current_answer_index && this.current_answer_index >= 0
+      answerLen > this.current_answer_index && this.current_answer_index >= 0
     );
   }
 }

--- a/src/models/noraQuestion.ts
+++ b/src/models/noraQuestion.ts
@@ -19,6 +19,7 @@ export interface NoraQuestionSelect {
   answerText: string;
 }
 
+// 野良認証
 export class NoraQuestion implements NoraQuestionModel {
   readonly id: number;
   readonly question_title: string;
@@ -38,5 +39,24 @@ export class NoraQuestion implements NoraQuestionModel {
 
     this.current_answer_index = init.current_answer_index;
     this.score = init.score;
+  }
+
+  // 回答を返す
+  get answer(): NoraQuestionSelect {
+    return this.answers[this.current_answer_index];
+  }
+
+  // current_answer_indexがanswersの範囲内に存在するかチェックする
+  // 回答が存在しない場合はundefined
+  public checkAnswer(): boolean | undefined {
+    const answerLen = this.answers.length;
+
+    if (answerLen === 0) {
+      return;
+    }
+
+    return (
+      answerLen >= this.current_answer_index && this.current_answer_index >= 0
+    );
   }
 }

--- a/src/models/noraQuestion.ts
+++ b/src/models/noraQuestion.ts
@@ -1,0 +1,42 @@
+export interface NoraQuestionModel {
+  id: number;
+
+  // 問題のタイトル
+  question_title: string;
+
+  // 答えの選択肢
+  answers: NoraQuestionSelect[];
+
+  // 答えの回答
+  current_answer_index: number;
+
+  // この問題の重み
+  score: number;
+}
+
+export interface NoraQuestionSelect {
+  index: number;
+  answerText: string;
+}
+
+export class NoraQuestion implements NoraQuestionModel {
+  readonly id: number;
+  readonly question_title: string;
+  readonly answers: NoraQuestionSelect[];
+  readonly current_answer_index: number;
+  readonly score: number;
+
+  constructor(init: NoraQuestionModel) {
+    this.id = init.id;
+    this.question_title = init.question_title;
+
+    if (typeof init.answers === 'object') {
+      this.answers = init.answers;
+    } else {
+      this.answers = JSON.parse(init.answers) as NoraQuestionSelect[];
+    }
+
+    this.current_answer_index = init.current_answer_index;
+    this.score = init.score;
+  }
+}

--- a/src/services/noraQuestion.ts
+++ b/src/services/noraQuestion.ts
@@ -139,11 +139,19 @@ export async function findNoraQuestionById(
 /**
  *
  * @param {Connection} db - database
+ * @param {number} limit - limit
  */
 export async function findAllNoraQuestion(
-  db: Connection
+  db: Connection,
+  limit?: number
 ): Promise<NoraQuestion[]> {
-  const query = select('*').from('nora_question').toParams({placeholder: '?'});
+  let q = select('*').from('nora_question');
+
+  if (limit) {
+    q = q.limit(limit);
+  }
+
+  const query = q.toParams({placeholder: '?'});
 
   const [row] = await db.query<RowDataPacket[]>(query.text, query.values);
 

--- a/src/services/noraQuestion.ts
+++ b/src/services/noraQuestion.ts
@@ -32,7 +32,7 @@ export async function createNoraQuestion(
 ): Promise<NoraQuestion> {
   // answerIndexが範囲外のときはエラー
   if (answerIndex < 0 || answerIndex >= answers.length) {
-    throw new ApiError(500, 'answerIndex is out of answers index');
+    throw new ApiError(400, 'answerIndex is out of answers index');
   }
 
   const query = insert('nora_question', {
@@ -78,21 +78,23 @@ export async function updateNoraQuestionByID(
   }
 
   // 値が正しいかチェックする
-  if (
-    d.current_answer_index &&
-    d.answers &&
-    (d.current_answer_index < 0 || d.current_answer_index >= d.answers.length)
-  ) {
-    throw new ApiError(500, 'answerIndex is out of answers index');
-  } else if (
-    d.current_answer_index &&
-    (d.current_answer_index < 0 || d.current_answer_index > q.answers.length)
-  ) {
-    // answerIndexをしている場合、すでにテーブルに存在しているanswersをみて範囲内か判定する
-    throw new ApiError(500, 'answerIndex is out of answers index');
-  } else if (d.answers && q.current_answer_index >= d.answers.length) {
-    // answersを指定している場合、も上に同じ
-    throw new ApiError(500, 'answerIndex is out of answers index');
+  if (typeof d.current_answer_index === 'number' && d.answers) {
+    if (
+      d.current_answer_index < 0 ||
+      d.current_answer_index >= d.answers.length
+    )
+      throw new ApiError(400, 'answerIndex is out of answers index');
+  } else if (typeof d.current_answer_index === 'number') {
+    if (
+      d.current_answer_index < 0 ||
+      d.current_answer_index >= q.answers.length
+    )
+      // answerIndexをしている場合、すでにテーブルに存在しているanswersをみて範囲内か判定する
+      throw new ApiError(400, 'answerIndex is out of db answers index');
+  } else if (d.answers) {
+    if (q.current_answer_index >= d.answers.length)
+      // answersを指定している場合、も上に同じ
+      throw new ApiError(400, 'db answerIndex is out of answers index');
   }
 
   const _d: {[key: string]: Object | string | number} = {

--- a/src/services/noraQuestion.ts
+++ b/src/services/noraQuestion.ts
@@ -1,0 +1,83 @@
+import {insert, select} from 'mysql-bricks';
+import type {Connection, ResultSetHeader, RowDataPacket} from 'mysql2/promise';
+import {ApiError} from 'next/dist/server/api-utils';
+import {
+  NoraQuestion,
+  NoraQuestionModel,
+  NoraQuestionSelect,
+} from '../models/noraQuestion';
+
+/**
+ * 野良認証のクイズを追加する
+ *
+ * @param db
+ * @param title
+ * @param answers
+ * @param answerIndex
+ * @param score
+ */
+export async function createNoraQuestion(
+  db: Connection,
+  title: string,
+  answers: NoraQuestionSelect[],
+  answerIndex: number,
+  score: number
+) {
+  const query = insert('nora_question', {
+    question_title: title,
+    answers: JSON.stringify(answers),
+    current_answer_index: answerIndex,
+    score: score,
+  }).toParams({placeholder: '?'});
+
+  const [rows] = await db.query<ResultSetHeader>(query.text, query.values);
+
+  const id = rows.insertId;
+
+  return new NoraQuestion({
+    id: id,
+    question_title: title,
+    answers: answers,
+    current_answer_index: answerIndex,
+    score: score,
+  });
+}
+
+/**
+ * 野良認証のクイズをidで引く
+ *
+ * @param db
+ * @param id
+ */
+export async function findNoraQuestionById(db: Connection, id: number) {
+  const query = select('*')
+    .from('nora_question')
+    .where('id', id)
+    .toParams({placeholder: '?'});
+
+  const [row] = await db.query<RowDataPacket[]>(query.text, query.values);
+
+  if (row.length === 0) {
+    return null;
+  }
+
+  return new NoraQuestion(row[0] as NoraQuestionModel);
+}
+
+/**
+ *
+ * @param db
+ */
+export async function findAllNoraQuestion(db: Connection) {
+  const query = select('*').from('nora_question').toParams({placeholder: '?'});
+
+  const [row] = await db.query<RowDataPacket[]>(query.text, query.values);
+
+  const n = [];
+
+  for (const r of row) {
+    n.push(new NoraQuestion(r as NoraQuestionModel));
+  }
+
+  return n;
+}

--- a/tests/admin/noraQuestion.test.ts
+++ b/tests/admin/noraQuestion.test.ts
@@ -1,0 +1,452 @@
+import {randomInt} from 'crypto';
+import mysql from 'mysql2/promise';
+import {testApiHandler} from 'next-test-api-route-handler';
+import config from '../../config';
+import {get, post, put, _delete} from '../../src/admin/noraQuestion';
+import {NoraQuestion, NoraQuestionModel} from '../../src/models/noraQuestion';
+import {
+  createNoraQuestion,
+  findNoraQuestionById,
+} from '../../src/services/noraQuestion';
+import {TestUser} from '../../src/tests/user';
+
+describe('noraQuestion', () => {
+  let db: mysql.Connection;
+  const user = new TestUser({is_admin: true});
+  const normalUser = new TestUser();
+
+  const dummyQuestion: NoraQuestionModel = {
+    id: NaN,
+    question_title: 'hogehoge',
+    answers: [
+      {
+        index: 0,
+        answerText: 'aaaa',
+      },
+      {
+        index: 1,
+        answerText: 'bbbb',
+      },
+    ],
+    current_answer_index: 0,
+    score: 100,
+  };
+
+  beforeAll(async () => {
+    db = await mysql.createConnection(config.db);
+    await db.connect();
+
+    await user.create(db);
+    await user.addSession(db);
+
+    await normalUser.create(db);
+    await normalUser.addSession(db);
+  });
+
+  afterAll(async () => {
+    await db.end();
+  });
+
+  test('get', async () => {
+    expect.hasAssertions();
+
+    const question = await createNoraQuestion(
+      db,
+      dummyQuestion.question_title,
+      dummyQuestion.answers,
+      dummyQuestion.current_answer_index,
+      dummyQuestion.score
+    );
+
+    await testApiHandler({
+      handler: get,
+      requestPatcher: async req => {
+        req.headers = {
+          cookie: user.sessionCookie,
+        };
+      },
+      test: async ({fetch}) => {
+        const res = await fetch();
+        expect(res.status).toBe(200);
+
+        const d = await res.json();
+
+        // 存在する
+        expect(d.find(v => v.id === question.id)).not.toBeUndefined();
+      },
+    });
+  });
+
+  test('getで管理者以外は403', async () => {
+    await testApiHandler({
+      handler: get,
+      requestPatcher: async req => {
+        req.headers = {
+          cookie: normalUser.sessionCookie,
+        };
+      },
+      test: async ({fetch}) => {
+        const res = await fetch();
+        expect(res.status).toBe(403);
+      },
+    });
+  });
+
+  test('getでlimitあり', async () => {
+    expect.hasAssertions();
+
+    // 3個追加する
+    for (let i = 0; 3 > i; ++i) {
+      await createNoraQuestion(
+        db,
+        dummyQuestion.question_title,
+        dummyQuestion.answers,
+        dummyQuestion.current_answer_index,
+        dummyQuestion.score
+      );
+    }
+
+    await testApiHandler({
+      handler: get,
+      requestPatcher: async req => {
+        req.headers = {
+          cookie: user.sessionCookie,
+        };
+      },
+      url: '/?limit=2',
+      test: async ({fetch}) => {
+        const res = await fetch();
+        expect(res.status).toBe(200);
+
+        const d = await res.json();
+
+        expect(d.length).toBe(2);
+      },
+    });
+  });
+
+  test('post', async () => {
+    expect.hasAssertions();
+
+    await testApiHandler({
+      handler: post,
+      requestPatcher: async req => {
+        req.headers = {
+          cookie: user.sessionCookie,
+          'content-type': 'application/json',
+        };
+      },
+      test: async ({fetch}) => {
+        const res = await fetch({
+          method: 'POST',
+          body: JSON.stringify({
+            question_title: dummyQuestion.question_title,
+            answers: [
+              dummyQuestion.answers[0].answerText,
+              dummyQuestion.answers[1].answerText,
+            ],
+            current_answer_index: dummyQuestion.current_answer_index,
+            score: dummyQuestion.score,
+          }),
+        });
+        expect(res.status).toBe(200);
+
+        const d = await res.json();
+
+        const q = findNoraQuestionById(db, d.id);
+
+        expect(q).not.toBeNull();
+      },
+    });
+  });
+
+  test('postで管理者以外は403', async () => {
+    await testApiHandler({
+      handler: post,
+      requestPatcher: async req => {
+        req.headers = {
+          cookie: normalUser.sessionCookie,
+        };
+      },
+      test: async ({fetch}) => {
+        const res = await fetch();
+        expect(res.status).toBe(403);
+      },
+    });
+  });
+
+  test('postでフォームが完全でないとエラー: answers', async () => {
+    expect.hasAssertions();
+
+    await testApiHandler({
+      handler: post,
+      requestPatcher: async req => {
+        req.headers = {
+          cookie: user.sessionCookie,
+          'content-type': 'application/json',
+        };
+      },
+      test: async ({fetch}) => {
+        const res = await fetch({
+          method: 'POST',
+          body: JSON.stringify({
+            question_title: dummyQuestion.question_title,
+            current_answer_index: dummyQuestion.current_answer_index,
+            score: dummyQuestion.score,
+          }),
+        });
+        expect(res.status).toBe(400);
+      },
+    });
+  });
+
+  test('postでフォームが完全でないとエラー: score', async () => {
+    expect.hasAssertions();
+
+    await testApiHandler({
+      handler: post,
+      requestPatcher: async req => {
+        req.headers = {
+          cookie: user.sessionCookie,
+          'content-type': 'application/json',
+        };
+      },
+      test: async ({fetch}) => {
+        const res = await fetch({
+          method: 'POST',
+          body: JSON.stringify({
+            question_title: dummyQuestion.question_title,
+            answers: [
+              dummyQuestion.answers[0].answerText,
+              dummyQuestion.answers[1].answerText,
+            ],
+            current_answer_index: dummyQuestion.current_answer_index,
+          }),
+        });
+        expect(res.status).toBe(400);
+      },
+    });
+  });
+
+  test('postでcurrent_answer_indexが範囲外だとエラー', async () => {
+    expect.hasAssertions();
+
+    await testApiHandler({
+      handler: post,
+      requestPatcher: async req => {
+        req.headers = {
+          cookie: user.sessionCookie,
+          'content-type': 'application/json',
+        };
+      },
+      test: async ({fetch}) => {
+        const res = await fetch({
+          method: 'POST',
+          body: JSON.stringify({
+            question_title: dummyQuestion.question_title,
+            answers: [
+              dummyQuestion.answers[0].answerText,
+              dummyQuestion.answers[1].answerText,
+            ],
+            current_answer_index: 100,
+          }),
+        });
+        expect(res.status).toBe(400);
+      },
+    });
+  });
+
+  test('put', async () => {
+    expect.hasAssertions();
+
+    const question = await createNoraQuestion(
+      db,
+      dummyQuestion.question_title,
+      dummyQuestion.answers,
+      dummyQuestion.current_answer_index,
+      dummyQuestion.score
+    );
+
+    const newTitle = 'netai';
+    const newAns = ['uooooooooooooooo'];
+    const newAnsI = 0;
+    const newScore = 1000;
+
+    await testApiHandler({
+      handler: put,
+      requestPatcher: async req => {
+        req.headers = {
+          cookie: user.sessionCookie,
+          'content-type': 'application/json',
+        };
+      },
+      test: async ({fetch}) => {
+        const res = await fetch({
+          method: 'PUT',
+          body: JSON.stringify({
+            id: question.id,
+            question_title: newTitle,
+            answers: newAns,
+            current_answer_index: newAnsI,
+            score: newScore,
+          }),
+        });
+        expect(res.status).toBe(200);
+
+        const q = await findNoraQuestionById(db, question.id);
+
+        const _q = new NoraQuestion({
+          id: question.id,
+          question_title: newTitle,
+          answers: [
+            {
+              index: 0,
+              answerText: newAns[0],
+            },
+          ],
+          current_answer_index: newAnsI,
+          score: newScore,
+        });
+
+        expect(q).toEqual(_q);
+      },
+    });
+  });
+
+  test('putで管理者以外は403', async () => {
+    await testApiHandler({
+      handler: put,
+      requestPatcher: async req => {
+        req.headers = {
+          cookie: normalUser.sessionCookie,
+        };
+      },
+      test: async ({fetch}) => {
+        const res = await fetch();
+        expect(res.status).toBe(403);
+      },
+    });
+  });
+
+  test('putで指定しないカラムは変更しない', async () => {
+    expect.hasAssertions();
+
+    const question = await createNoraQuestion(
+      db,
+      dummyQuestion.question_title,
+      dummyQuestion.answers,
+      dummyQuestion.current_answer_index,
+      dummyQuestion.score
+    );
+
+    const newAns = ['uooooooooooooooo'];
+    const newAnsI = 0;
+    const newScore = 1000;
+
+    await testApiHandler({
+      handler: put,
+      requestPatcher: async req => {
+        req.headers = {
+          cookie: user.sessionCookie,
+          'content-type': 'application/json',
+        };
+      },
+      test: async ({fetch}) => {
+        const res = await fetch({
+          method: 'PUT',
+          body: JSON.stringify({
+            id: question.id,
+            answers: newAns,
+            current_answer_index: newAnsI,
+            score: newScore,
+          }),
+        });
+        expect(res.status).toBe(200);
+
+        const q = await findNoraQuestionById(db, question.id);
+
+        const _q = new NoraQuestion({
+          id: question.id,
+          question_title: dummyQuestion.question_title,
+          answers: [
+            {
+              index: 0,
+              answerText: newAns[0],
+            },
+          ],
+          current_answer_index: newAnsI,
+          score: newScore,
+        });
+
+        expect(q).toEqual(_q);
+      },
+    });
+  });
+
+  test('delete', async () => {
+    expect.hasAssertions();
+
+    const question = await createNoraQuestion(
+      db,
+      dummyQuestion.question_title,
+      dummyQuestion.answers,
+      dummyQuestion.current_answer_index,
+      dummyQuestion.score
+    );
+
+    await testApiHandler({
+      handler: _delete,
+      requestPatcher: async req => {
+        req.headers = {
+          cookie: user.sessionCookie,
+        };
+      },
+      url: `/?id=${question.id}`,
+      test: async ({fetch}) => {
+        const res = await fetch({
+          method: 'DELETE',
+        });
+        expect(res.status).toBe(200);
+
+        const q = await findNoraQuestionById(db, question.id);
+
+        expect(q).toBeNull();
+      },
+    });
+  });
+
+  test('deleteで管理者以外は403', async () => {
+    await testApiHandler({
+      handler: _delete,
+      requestPatcher: async req => {
+        req.headers = {
+          cookie: normalUser.sessionCookie,
+        };
+      },
+      test: async ({fetch}) => {
+        const res = await fetch();
+        expect(res.status).toBe(403);
+      },
+    });
+  });
+
+  test('deleteで存在しないIDでも200', async () => {
+    expect.hasAssertions();
+
+    await testApiHandler({
+      handler: _delete,
+      requestPatcher: async req => {
+        req.headers = {
+          cookie: user.sessionCookie,
+        };
+      },
+      url: `/?id=${randomInt(1000)}`,
+      test: async ({fetch}) => {
+        const res = await fetch({
+          method: 'DELETE',
+        });
+        expect(res.status).toBe(200);
+      },
+    });
+  });
+});

--- a/tests/base/authedBase.test.ts
+++ b/tests/base/authedBase.test.ts
@@ -145,4 +145,58 @@ describe('login', () => {
       },
     });
   });
+
+  test('adminOnly', async () => {
+    expect.hasAssertions();
+
+    const handler = async (base: AuthedBase<void>) => {
+      base.adminOnly();
+    };
+
+    const h = authHandlerWrapper(handler, 'GET');
+
+    const user = new TestUser({is_admin: true});
+    await user.create(db);
+    await user.addSession(db);
+
+    await testApiHandler({
+      handler: h,
+      requestPatcher: async req => {
+        req.headers = {
+          cookie: user.sessionCookie,
+        };
+      },
+      test: async ({fetch}) => {
+        const res = await fetch();
+        expect(res.status).toBe(200);
+      },
+    });
+  });
+
+  test('adminOnlyで通常ユーザ', async () => {
+    expect.hasAssertions();
+
+    const handler = async (base: AuthedBase<void>) => {
+      base.adminOnly();
+    };
+
+    const h = authHandlerWrapper(handler, 'GET');
+
+    const user = new TestUser();
+    await user.create(db);
+    await user.addSession(db);
+
+    await testApiHandler({
+      handler: h,
+      requestPatcher: async req => {
+        req.headers = {
+          cookie: user.sessionCookie,
+        };
+      },
+      test: async ({fetch}) => {
+        const res = await fetch();
+        expect(res.status).toBe(403);
+      },
+    });
+  });
 });

--- a/tests/models/noraQuestion.test.ts
+++ b/tests/models/noraQuestion.test.ts
@@ -1,5 +1,9 @@
 import {randomInt} from 'crypto';
-import {NoraQuestion, NoraQuestionSelect} from '../../src/models/noraQuestion';
+import {
+  NoraQuestion,
+  NoraQuestionModel,
+  NoraQuestionSelect,
+} from '../../src/models/noraQuestion';
 
 describe('noraQuestion', () => {
   const answers: NoraQuestionSelect[] = [
@@ -90,5 +94,25 @@ describe('noraQuestion', () => {
     });
 
     expect(q.checkAnswer()).toBeUndefined();
+  });
+
+  test('getModel', () => {
+    const q = new NoraQuestion({
+      id: id,
+      question_title: title,
+      answers: answers,
+      current_answer_index: answerIndex,
+      score: score,
+    });
+
+    const m: NoraQuestionModel = {
+      id: id,
+      question_title: title,
+      answers: answers,
+      current_answer_index: answerIndex,
+      score: score,
+    };
+
+    expect(q.model).toEqual(m);
   });
 });

--- a/tests/models/noraQuestion.test.ts
+++ b/tests/models/noraQuestion.test.ts
@@ -1,0 +1,94 @@
+import {randomInt} from 'crypto';
+import {NoraQuestion, NoraQuestionSelect} from '../../src/models/noraQuestion';
+
+describe('noraQuestion', () => {
+  const answers: NoraQuestionSelect[] = [
+    {
+      index: 0,
+      answerText: 'hogehoge',
+    },
+    {
+      index: 1,
+      answerText: 'hugahuga',
+    },
+  ];
+  const id = randomInt(20);
+  const title = 'nyaaa';
+  const answerIndex = 1;
+  const score = 90;
+
+  test('作成できる', () => {
+    const q = new NoraQuestion({
+      id: id,
+      question_title: title,
+      answers: answers,
+      current_answer_index: answerIndex,
+      score: score,
+    });
+
+    expect(q.id).toBe(id);
+    expect(q.question_title).toBe(title);
+    expect(q.current_answer_index).toBe(answerIndex);
+    expect(q.score).toBe(score);
+  });
+
+  test('回答を返す', () => {
+    const q = new NoraQuestion({
+      id: id,
+      question_title: title,
+      answers: answers,
+      current_answer_index: answerIndex,
+      score: score,
+    });
+
+    expect(q.answer).toBe(answers[answerIndex]);
+  });
+
+  test('回答のインデックスが正しい', () => {
+    const q = new NoraQuestion({
+      id: id,
+      question_title: title,
+      answers: answers,
+      current_answer_index: answerIndex,
+      score: score,
+    });
+
+    expect(q.checkAnswer()).toBe(true);
+  });
+
+  test('回答のインデックスが範囲外だとfalse', () => {
+    const q = new NoraQuestion({
+      id: id,
+      question_title: title,
+      answers: answers,
+      current_answer_index: 10000, // 範囲外
+      score: score,
+    });
+
+    expect(q.checkAnswer()).toBe(false);
+  });
+
+  test('回答のインデックスが0より小さいとfalse', () => {
+    const q = new NoraQuestion({
+      id: id,
+      question_title: title,
+      answers: answers,
+      current_answer_index: -100, // 負の値のインデックスは理論上ありえない
+      score: score,
+    });
+
+    expect(q.checkAnswer()).toBe(false);
+  });
+
+  test('回答が存在しない場合はundefined', () => {
+    const q = new NoraQuestion({
+      id: id,
+      question_title: title,
+      answers: [], // 回答が存在しない
+      current_answer_index: answerIndex,
+      score: score,
+    });
+
+    expect(q.checkAnswer()).toBeUndefined();
+  });
+});

--- a/tests/service/norQuestion.test.ts
+++ b/tests/service/norQuestion.test.ts
@@ -107,6 +107,26 @@ describe('noraQuestion', () => {
     expect(questions.find(v => v.id === id)).not.toBeUndefined();
   });
 
+  test('findAllNoraQuestionのlimit付き', async () => {
+    // 3つ追加
+    for (let i = 0; 3 > i; i++) {
+      await db.query<ResultSetHeader>(
+        `INSERT INTO nora_question(
+        question_title,
+        answers,
+        current_answer_index,
+        score
+      ) VALUES (?, ?, ?, ?)`,
+        [title, JSON.stringify(answers), answerIndex, score]
+      );
+    }
+
+    const questions = await findAllNoraQuestion(db, 2);
+
+    // 0 = 空という判断
+    expect(questions.length).toBe(2);
+  });
+
   test('findRandomNoraQuestion', async () => {
     // 最低2個の問題を格納する
     for (let i = 0; 2 > i; ++i) {

--- a/tests/service/norQuestion.test.ts
+++ b/tests/service/norQuestion.test.ts
@@ -247,13 +247,13 @@ describe('noraQuestion', () => {
       await updateNoraQuestionByID(db, id, {
         current_answer_index: 10, // 範囲外に更新する
       });
-    }).rejects.toThrow('answerIndex is out of answers index');
+    }).rejects.toThrow('answerIndex is out of db answers index');
 
     expect(async () => {
       await updateNoraQuestionByID(db, id, {
         current_answer_index: -1, // 負の値
       });
-    }).rejects.toThrow('answerIndex is out of answers index');
+    }).rejects.toThrow('answerIndex is out of db answers index');
   });
 
   test('updateNoraQuestionByIDで範囲外になるようなanswersを更新する', async () => {

--- a/tests/service/norQuestion.test.ts
+++ b/tests/service/norQuestion.test.ts
@@ -171,7 +171,7 @@ describe('noraQuestion', () => {
   });
 
   test('存在しないIDでdeleteNoraQuestionByID', async () => {
-    const id = randomInt(10);
+    const id = randomInt(10000);
 
     expect(async () => {
       await deleteNoraQuestionByID(db, id);

--- a/tests/service/norQuestion.test.ts
+++ b/tests/service/norQuestion.test.ts
@@ -1,0 +1,155 @@
+import {randomInt} from 'crypto';
+import mysql, {ResultSetHeader, RowDataPacket} from 'mysql2/promise';
+import config from '../../config';
+import {NoraQuestion, NoraQuestionSelect} from '../../src/models/noraQuestion';
+import {
+  createNoraQuestion,
+  deleteNoraQuestionByID,
+  findAllNoraQuestion,
+  findNoraQuestionById,
+  findRandomNoraQuestion,
+} from '../../src/services/noraQuestion';
+
+describe('noraQuestion', () => {
+  let db: mysql.Connection;
+
+  const answers: NoraQuestionSelect[] = [
+    {
+      index: 0,
+      answerText: 'hogehoge',
+    },
+    {
+      index: 1,
+      answerText: 'hugahuga',
+    },
+  ];
+  const title = 'nyaaa';
+  const answerIndex = 1;
+  const score = 90;
+
+  beforeAll(async () => {
+    db = await mysql.createConnection(config.db);
+    await db.connect();
+  });
+
+  afterAll(async () => {
+    await db.end();
+  });
+
+  test('createNoraQuestion', async () => {
+    const q = await createNoraQuestion(db, title, answers, answerIndex, score);
+
+    // 返ってくる値が正しい
+    expect(typeof q.id === 'number').toBeTruthy();
+    expect(q.question_title).toBe(title);
+    expect(q.current_answer_index).toBe(answerIndex);
+    expect(q.score).toBe(score);
+
+    // dbに格納されている
+    const [r] = await db.query<RowDataPacket[]>(
+      'SELECT id FROM nora_question WHERE id = ?',
+      q.id
+    );
+
+    expect(r[0].id).toBe(q.id);
+  });
+
+  test('findNoraQuestionById', async () => {
+    const [rows] = await db.query<ResultSetHeader>(
+      `INSERT INTO nora_question(
+      question_title,
+      answers,
+      current_answer_index,
+      score
+    ) VALUES (?, ?, ?, ?)`,
+      [title, JSON.stringify(answers), answerIndex, score]
+    );
+
+    const id = rows.insertId;
+
+    const q = await findNoraQuestionById(db, id);
+
+    const qq = new NoraQuestion({
+      id: id,
+      question_title: title,
+      answers: answers,
+      current_answer_index: answerIndex,
+      score: score,
+    });
+
+    expect(q).toEqual(qq);
+  });
+
+  test('findAllNoraQuestion', async () => {
+    const [rows] = await db.query<ResultSetHeader>(
+      `INSERT INTO nora_question(
+      question_title,
+      answers,
+      current_answer_index,
+      score
+    ) VALUES (?, ?, ?, ?)`,
+      [title, JSON.stringify(answers), answerIndex, score]
+    );
+
+    const id = rows.insertId;
+
+    const questions = await findAllNoraQuestion(db);
+
+    // 0 = 空という判断
+    expect(questions.length).not.toBe(0);
+
+    // idのnora questionが存在する
+    expect(questions.find(v => v.id === id)).not.toBeUndefined();
+  });
+
+  test('findRandomNoraQuestion', async () => {
+    // 最低2個の問題を格納する
+    for (let i = 0; 2 > i; ++i) {
+      await db.query<ResultSetHeader>(
+        `INSERT INTO nora_question(
+        question_title,
+        answers,
+        current_answer_index,
+        score
+      ) VALUES (?, ?, ?, ?)`,
+        [title, JSON.stringify(answers), answerIndex, score]
+      );
+    }
+
+    const questions = await findRandomNoraQuestion(db, 2);
+
+    expect(questions.length).toBe(2);
+  });
+
+  test('deleteNoraQuestionByID', async () => {
+    const [rows] = await db.query<ResultSetHeader>(
+      `INSERT INTO nora_question(
+      question_title,
+      answers,
+      current_answer_index,
+      score
+    ) VALUES (?, ?, ?, ?)`,
+      [title, JSON.stringify(answers), answerIndex, score]
+    );
+
+    const id = rows.insertId;
+
+    await deleteNoraQuestionByID(db, id);
+
+    // DBから消えている
+    const [r] = await db.query<RowDataPacket[]>(
+      'SELECT id FROM nora_question WHERE id = ?',
+      id
+    );
+
+    expect(r.length).toBe(0);
+  });
+
+  test('存在しないIDでdeleteNoraQuestionByID', async () => {
+    const id = randomInt(10);
+
+    expect(async () => {
+      await deleteNoraQuestionByID(db, id);
+    }).not.toThrow();
+  });
+});


### PR DESCRIPTION
- issue: https://github.com/team-ful/noratomo/issues/9

## 🔧 修正点

- [x] `is_admin`がtureのユーザに対し、野良認証の問題をPOST、GET、PUT、DELETEできるようにする

## ✅ 自己チェック

- [x] 動作確認ができているか
- [x] 新しく追加したメソッドにユニットテストを追加しているか
- [x] 静的解析、テストは成功しているか
- [x] `Files changed`を自分で確認してミスがないか

## 📸 スクリーンショット（オプション）

## ⚠️ レビュー時に注意して欲しいこと（オプション）

## 🗣️ 補足など（オプション）
