### PR TITLE
ログインを維持してログインしているときはユーザの情報を保持しておく

### DIFF
--- a/components/Hello.tsx
+++ b/components/Hello.tsx
@@ -1,0 +1,15 @@
+import {Box, Center, Heading, Skeleton} from '@chakra-ui/react';
+import useUser from './Session/useUser';
+
+const Hello = () => {
+  const user = useUser();
+  return (
+    <Center h="80vh">
+      <Skeleton isLoaded={typeof user !== 'undefined'}>
+        <Heading>ようこそ {user?.user_name} さん</Heading>
+      </Skeleton>
+    </Center>
+  );
+};
+
+export default Hello;

--- a/components/Hello.tsx
+++ b/components/Hello.tsx
@@ -1,4 +1,4 @@
-import {Box, Center, Heading, Skeleton} from '@chakra-ui/react';
+import {Center, Heading, Skeleton} from '@chakra-ui/react';
 import useUser from './Session/useUser';
 
 const Hello = () => {

--- a/components/Session/Me.tsx
+++ b/components/Session/Me.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import {useSetRecoilState} from 'recoil';
+import {UserState} from '../../utils/atom';
+import cookieValue from '../../utils/cookie';
+import useGetUser from './useGetUser';
+
+const Me = () => {
+  const [get] = useGetUser();
+  const setUser = useSetRecoilState(UserState);
+
+  React.useEffect(() => {
+    if (typeof window !== 'undefined') {
+      const checkCookie = cookieValue('noratomo-options');
+
+      if (checkCookie) {
+        get();
+      } else {
+        setUser(null);
+      }
+    }
+  }, []);
+
+  return <></>;
+};
+
+export default Me;

--- a/components/Session/Require.tsx
+++ b/components/Session/Require.tsx
@@ -1,0 +1,56 @@
+import {Skeleton, Box} from '@chakra-ui/react';
+import {useRouter} from 'next/router';
+import React from 'react';
+import {useRecoilValue} from 'recoil';
+import {UserState} from '../../utils/atom';
+
+interface Props {
+  children: React.ReactNode;
+  loginRequire: boolean;
+  path: string;
+  adminOnly?: boolean;
+  load?: React.ReactNode;
+}
+
+const Require: React.FC<Props> = ({
+  children,
+  loginRequire,
+  path,
+  adminOnly,
+  load,
+}) => {
+  const [show, setShow] = React.useState(false);
+  const user = useRecoilValue(UserState);
+  const router = useRouter();
+
+  React.useEffect(() => {
+    if (typeof user !== 'undefined') {
+      if ((user === null) === loginRequire) {
+        router.replace(path);
+      } else {
+        if (adminOnly && !user?.is_admin) {
+          // adminOnlyのページにアクセスしたのにユーザがadminではない場合
+          router.replace(path);
+        } else {
+          setShow(true);
+        }
+      }
+    }
+  }, [user]);
+
+  return (
+    <>
+      {show ? (
+        <Box minH="80vh">{children}</Box>
+      ) : load ? (
+        load
+      ) : (
+        <Skeleton>
+          <Box w="100%" h="80vh"></Box>
+        </Skeleton>
+      )}
+    </>
+  );
+};
+
+export default Require;

--- a/components/Session/useGetUser.tsx
+++ b/components/Session/useGetUser.tsx
@@ -1,0 +1,32 @@
+import {useSetRecoilState} from 'recoil';
+import {UserState} from '../../utils/atom';
+
+const useGetUser = (): [() => void] => {
+  const setUser = useSetRecoilState(UserState);
+
+  const get = () => {
+    const f = async () => {
+      const res = await fetch('/api/user/me');
+
+      if (res.ok) {
+        const u = await res.json();
+
+        setUser({
+          ...u,
+          join_date: new Date(u.join_date),
+        });
+      } else if (res.status === 403) {
+        setUser(null);
+      } else {
+        // なにかしたい気がする
+        setUser(null);
+      }
+    };
+
+    f();
+  };
+
+  return [get];
+};
+
+export default useGetUser;

--- a/components/Session/useUser.tsx
+++ b/components/Session/useUser.tsx
@@ -1,0 +1,8 @@
+import {useRecoilValue} from 'recoil';
+import {UserState} from '../../utils/atom';
+
+const useUser = () => {
+  return useRecoilValue(UserState);
+};
+
+export default useUser;

--- a/config/config.ts
+++ b/config/config.ts
@@ -27,6 +27,11 @@ export interface Config {
   refreshPeriodDay: number;
   refreshCookieOptions: () => CookieSerializeOptions;
 
+  // other information cookies
+  // ログイン状態判定などに使用する
+  otherCookieName: string;
+  otherCookieOptions: () => CookieSerializeOptions;
+
   // DB
   db: ConnectionOptions;
 }

--- a/config/config.ts
+++ b/config/config.ts
@@ -16,11 +16,13 @@ export interface Config {
   cateiruSSOClientSecret: string;
 
   // session cookie
+  sessionTokenLen: number;
   sessionCookieName: string;
   sessionPeriodDay: number;
   sessionCookieOptions: () => CookieSerializeOptions;
 
   // refresh cookie
+  refreshTokenLen: number;
   refreshCookieName: string;
   refreshPeriodDay: number;
   refreshCookieOptions: () => CookieSerializeOptions;

--- a/config/config.ts
+++ b/config/config.ts
@@ -20,6 +20,11 @@ export interface Config {
   sessionPeriodDay: number;
   sessionCookieOptions: () => CookieSerializeOptions;
 
+  // refresh cookie
+  refreshCookieName: string;
+  refreshPeriodDay: number;
+  refreshCookieOptions: () => CookieSerializeOptions;
+
   // DB
   db: ConnectionOptions;
 }

--- a/config/environments/local.ts
+++ b/config/environments/local.ts
@@ -35,6 +35,23 @@ const config: Config = {
     };
   },
 
+  refreshCookieName: 'noratomo-refresh',
+  refreshPeriodDay: 30,
+  refreshCookieOptions: () => {
+    const date = new Date(Date.now());
+    date.setDate(date.getDate() + config.sessionPeriodDay);
+
+    return {
+      domain: 'localhost',
+      expires: date,
+      maxAge: config.sessionPeriodDay * 24,
+      sameSite: 'strict',
+      secure: false, // テスト用であるためfalse
+      httpOnly: false, // クライアント側でcookieを読みたいためfalse
+      path: '/',
+    };
+  },
+
   db: {
     host: '127.0.0.1',
     user: 'docker',

--- a/config/environments/local.ts
+++ b/config/environments/local.ts
@@ -31,7 +31,7 @@ const config: Config = {
       maxAge: config.sessionPeriodDay * 24,
       sameSite: 'strict',
       secure: false, // テスト用であるためfalse
-      httpOnly: false, // クライアント側でcookieを読みたいためfalse
+      httpOnly: true,
       path: '/',
     };
   },
@@ -49,7 +49,18 @@ const config: Config = {
       maxAge: config.sessionPeriodDay * 24,
       sameSite: 'strict',
       secure: false, // テスト用であるためfalse
-      httpOnly: false, // クライアント側でcookieを読みたいためfalse
+      httpOnly: true,
+      path: '/',
+    };
+  },
+
+  otherCookieName: 'noratomo-options',
+  otherCookieOptions: () => {
+    return {
+      domain: 'localhost',
+      sameSite: 'strict',
+      secure: false,
+      httpOnly: false,
       path: '/',
     };
   },

--- a/config/environments/local.ts
+++ b/config/environments/local.ts
@@ -28,7 +28,7 @@ const config: Config = {
     return {
       domain: 'localhost',
       expires: date,
-      maxAge: config.sessionPeriodDay * 24,
+      maxAge: config.sessionPeriodDay * 86400,
       sameSite: 'strict',
       secure: false, // テスト用であるためfalse
       httpOnly: true,
@@ -41,12 +41,12 @@ const config: Config = {
   refreshPeriodDay: 30,
   refreshCookieOptions: () => {
     const date = new Date(Date.now());
-    date.setDate(date.getDate() + config.sessionPeriodDay);
+    date.setDate(date.getDate() + config.refreshPeriodDay);
 
     return {
       domain: 'localhost',
       expires: date,
-      maxAge: config.sessionPeriodDay * 24,
+      maxAge: config.refreshPeriodDay * 86400,
       sameSite: 'strict',
       secure: false, // テスト用であるためfalse
       httpOnly: true,
@@ -56,8 +56,13 @@ const config: Config = {
 
   otherCookieName: 'noratomo-options',
   otherCookieOptions: () => {
+    const date = new Date(Date.now());
+    date.setDate(date.getDate() + config.refreshPeriodDay);
+
     return {
       domain: 'localhost',
+      expires: date,
+      maxAge: config.refreshPeriodDay * 86400,
       sameSite: 'strict',
       secure: false,
       httpOnly: false,

--- a/config/environments/local.ts
+++ b/config/environments/local.ts
@@ -18,6 +18,7 @@ const config: Config = {
   cateiruSSOClientSecret:
     '0910c801ca06504e3d5d8db5b8adf81c123a40863e6749ac468e8b9f980024b0',
 
+  sessionTokenLen: 64,
   sessionCookieName: 'noratomo-session',
   sessionPeriodDay: 7,
   sessionCookieOptions: () => {
@@ -35,6 +36,7 @@ const config: Config = {
     };
   },
 
+  refreshTokenLen: 128,
   refreshCookieName: 'noratomo-refresh',
   refreshPeriodDay: 30,
   refreshCookieOptions: () => {

--- a/config/environments/production.ts
+++ b/config/environments/production.ts
@@ -12,6 +12,7 @@ const config: Config = {
   cateiruSSOClientSecret: '',
   cateiruSSOClientId: '',
 
+  sessionTokenLen: 64,
   sessionCookieName: 'noratomo-session',
   sessionPeriodDay: 7,
   sessionCookieOptions: () => {
@@ -29,6 +30,7 @@ const config: Config = {
     };
   },
 
+  refreshTokenLen: 128,
   refreshCookieName: 'noratomo-refresh',
   refreshPeriodDay: 30,
   refreshCookieOptions: () => {

--- a/config/environments/production.ts
+++ b/config/environments/production.ts
@@ -29,6 +29,23 @@ const config: Config = {
     };
   },
 
+  refreshCookieName: 'noratomo-refresh',
+  refreshPeriodDay: 30,
+  refreshCookieOptions: () => {
+    const date = new Date(Date.now());
+    date.setDate(date.getDate() + config.sessionPeriodDay);
+
+    return {
+      domain: 'localhost',
+      expires: date,
+      maxAge: config.sessionPeriodDay * 24,
+      sameSite: 'strict',
+      secure: false, // テスト用であるためfalse
+      httpOnly: false, // クライアント側でcookieを読みたいためfalse
+      path: '/',
+    };
+  },
+
   db: {
     host: 'db',
     user: 'docker',

--- a/config/environments/production.ts
+++ b/config/environments/production.ts
@@ -22,7 +22,7 @@ const config: Config = {
     return {
       domain: 'localhost',
       expires: date,
-      maxAge: config.sessionPeriodDay * 24,
+      maxAge: config.sessionPeriodDay * 86400,
       sameSite: 'strict',
       secure: false, // TODO: httpsにしてtrueにしたい
       httpOnly: true,
@@ -35,12 +35,12 @@ const config: Config = {
   refreshPeriodDay: 30,
   refreshCookieOptions: () => {
     const date = new Date(Date.now());
-    date.setDate(date.getDate() + config.sessionPeriodDay);
+    date.setDate(date.getDate() + config.refreshPeriodDay);
 
     return {
       domain: 'localhost',
       expires: date,
-      maxAge: config.sessionPeriodDay * 24,
+      maxAge: config.refreshPeriodDay * 86400,
       sameSite: 'strict',
       secure: false, // テスト用であるためfalse
       httpOnly: true,
@@ -50,8 +50,13 @@ const config: Config = {
 
   otherCookieName: 'noratomo-options',
   otherCookieOptions: () => {
+    const date = new Date(Date.now());
+    date.setDate(date.getDate() + config.refreshPeriodDay);
+
     return {
       domain: 'localhost',
+      expires: date,
+      maxAge: config.refreshPeriodDay * 86400,
       sameSite: 'strict',
       secure: false,
       httpOnly: false,

--- a/config/environments/production.ts
+++ b/config/environments/production.ts
@@ -25,7 +25,7 @@ const config: Config = {
       maxAge: config.sessionPeriodDay * 24,
       sameSite: 'strict',
       secure: false, // TODO: httpsにしてtrueにしたい
-      httpOnly: false, // クライアント側でcookieを読みたいためfalse
+      httpOnly: true,
       path: '/',
     };
   },
@@ -43,7 +43,18 @@ const config: Config = {
       maxAge: config.sessionPeriodDay * 24,
       sameSite: 'strict',
       secure: false, // テスト用であるためfalse
-      httpOnly: false, // クライアント側でcookieを読みたいためfalse
+      httpOnly: true,
+      path: '/',
+    };
+  },
+
+  otherCookieName: 'noratomo-options',
+  otherCookieOptions: () => {
+    return {
+      domain: 'localhost',
+      sameSite: 'strict',
+      secure: false,
+      httpOnly: false,
       path: '/',
     };
   },

--- a/config/environments/tests.ts
+++ b/config/environments/tests.ts
@@ -33,6 +33,23 @@ const config: Config = {
     };
   },
 
+  refreshCookieName: 'noratomo-refresh',
+  refreshPeriodDay: 30,
+  refreshCookieOptions: () => {
+    const date = new Date(Date.now());
+    date.setDate(date.getDate() + config.sessionPeriodDay);
+
+    return {
+      domain: 'localhost',
+      expires: date,
+      maxAge: config.sessionPeriodDay * 24,
+      sameSite: 'strict',
+      secure: false, // テスト用であるためfalse
+      httpOnly: false, // クライアント側でcookieを読みたいためfalse
+      path: '/',
+    };
+  },
+
   db: {
     host: '127.0.0.1',
     user: 'docker',

--- a/config/environments/tests.ts
+++ b/config/environments/tests.ts
@@ -29,7 +29,7 @@ const config: Config = {
       maxAge: config.sessionPeriodDay * 24,
       sameSite: 'strict',
       secure: false, // テスト用であるためfalse
-      httpOnly: false, // クライアント側でcookieを読みたいためfalse
+      httpOnly: true,
       path: '/',
     };
   },
@@ -46,8 +46,19 @@ const config: Config = {
       expires: date,
       maxAge: config.sessionPeriodDay * 24,
       sameSite: 'strict',
-      secure: false, // テスト用であるためfalse
-      httpOnly: false, // クライアント側でcookieを読みたいためfalse
+      secure: true,
+      httpOnly: true,
+      path: '/',
+    };
+  },
+
+  otherCookieName: 'noratomo-options',
+  otherCookieOptions: () => {
+    return {
+      domain: 'localhost',
+      sameSite: 'strict',
+      secure: false,
+      httpOnly: false,
       path: '/',
     };
   },

--- a/config/environments/tests.ts
+++ b/config/environments/tests.ts
@@ -16,6 +16,7 @@ const config: Config = {
   cateiruSSOClientSecret: 'cateiru-sso-client-id',
   cateiruSSOClientId: 'cateiru-sso-client-secret',
 
+  sessionTokenLen: 64,
   sessionCookieName: 'noratomo-session',
   sessionPeriodDay: 7,
   sessionCookieOptions: () => {
@@ -33,6 +34,7 @@ const config: Config = {
     };
   },
 
+  refreshTokenLen: 128,
   refreshCookieName: 'noratomo-refresh',
   refreshPeriodDay: 30,
   refreshCookieOptions: () => {

--- a/config/environments/tests.ts
+++ b/config/environments/tests.ts
@@ -26,7 +26,7 @@ const config: Config = {
     return {
       domain: 'localhost',
       expires: date,
-      maxAge: config.sessionPeriodDay * 24,
+      maxAge: config.sessionPeriodDay * 86400,
       sameSite: 'strict',
       secure: false, // テスト用であるためfalse
       httpOnly: true,
@@ -39,12 +39,12 @@ const config: Config = {
   refreshPeriodDay: 30,
   refreshCookieOptions: () => {
     const date = new Date(Date.now());
-    date.setDate(date.getDate() + config.sessionPeriodDay);
+    date.setDate(date.getDate() + config.refreshPeriodDay);
 
     return {
       domain: 'localhost',
       expires: date,
-      maxAge: config.sessionPeriodDay * 24,
+      maxAge: config.refreshPeriodDay * 86400,
       sameSite: 'strict',
       secure: true,
       httpOnly: true,
@@ -54,8 +54,13 @@ const config: Config = {
 
   otherCookieName: 'noratomo-options',
   otherCookieOptions: () => {
+    const date = new Date(Date.now());
+    date.setDate(date.getDate() + config.refreshPeriodDay);
+
     return {
       domain: 'localhost',
+      expires: date,
+      maxAge: config.refreshPeriodDay * 86400,
       sameSite: 'strict',
       secure: false,
       httpOnly: false,

--- a/db/sql/001_schema.sql
+++ b/db/sql/001_schema.sql
@@ -121,7 +121,7 @@ CREATE TABLE IF NOT EXISTS `refresh` (
     `period_date` DATETIME NOT NULL,
     `user_id` INT UNSIGNED NOT NULL,
     PRIMARY KEY (`refresh_token`)
-)
+);
 
 -- 投稿エントリ
 

--- a/db/sql/001_schema.sql
+++ b/db/sql/001_schema.sql
@@ -112,6 +112,17 @@ CREATE TABLE IF NOT EXISTS `session` (
     PRIMARY KEY (`session_token`)
 );
 
+-- リフレッシュトークン
+
+CREATE TABLE IF NOT EXISTS `refres` (
+    `refresh_token` VARCHAR(256) UNIQUE NOT NULL,
+    `session_token` VARCHAR(256) UNIQUE NOT NULL,
+    `date` DATETIME NOT NULL,
+    `period_date` DATETIME NOT NULL,
+    `user_id` INT UNSIGNED NOT NULL,
+    PRIMARY KEY (`refresh_token`)
+)
+
 -- 投稿エントリ
 
 CREATE TABLE IF NOT EXISTS `entry` (

--- a/db/sql/001_schema.sql
+++ b/db/sql/001_schema.sql
@@ -114,7 +114,7 @@ CREATE TABLE IF NOT EXISTS `session` (
 
 -- リフレッシュトークン
 
-CREATE TABLE IF NOT EXISTS `refres` (
+CREATE TABLE IF NOT EXISTS `refresh` (
     `refresh_token` VARCHAR(256) UNIQUE NOT NULL,
     `session_token` VARCHAR(256) UNIQUE NOT NULL,
     `date` DATETIME NOT NULL,

--- a/db/sql/002_event.sql
+++ b/db/sql/002_event.sql
@@ -4,3 +4,10 @@ CREATE EVENT IF NOT EXISTS clear_session
     COMMENT 'clear sessions table'
     DO
         DELETE FROM session WHERE period_date < NOW();
+
+CREATE EVENT IF NOT EXISTS clear_refresh_session
+    ON SCHEDULE
+        EVERY 1 HOUR
+    COMMENT 'clear refresh sessions table'
+    DO
+        DELETE FROM refresh WHERE period_date < NOW();

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -4,6 +4,7 @@ import Router from 'next/router';
 import nprogress from 'nprogress';
 import {RecoilRoot} from 'recoil';
 import {Frame} from '../components/Frame/Frame';
+import Me from '../components/Session/Me';
 import theme from '../utils/theme';
 
 import 'nprogress/nprogress.css';
@@ -27,6 +28,7 @@ const MyApp = ({Component, pageProps}: AppProps) => {
     <>
       <RecoilRoot>
         <ChakraProvider theme={theme}>
+          <Me />
           <Frame>
             <Component {...pageProps} />
           </Frame>

--- a/pages/_documents.tsx
+++ b/pages/_documents.tsx
@@ -1,9 +1,6 @@
 import {Html, Head, Main, NextScript} from 'next/document';
 
-/**
- *
- */
-export default function Document() {
+const Document = () => {
   return (
     <Html>
       <Head />
@@ -13,4 +10,6 @@ export default function Document() {
       </body>
     </Html>
   );
-}
+};
+
+export default Document;

--- a/pages/api/logout.ts
+++ b/pages/api/logout.ts
@@ -1,7 +1,5 @@
-import config from '../../config';
 import AuthedBase from '../../src/base/authedBase';
 import {authHandlerWrapper} from '../../src/base/handlerWrapper';
-import {deleteSessionBySessionToken} from '../../src/services/session';
 
 /**
  * パスワードを検証してログインする
@@ -9,10 +7,7 @@ import {deleteSessionBySessionToken} from '../../src/services/session';
  * @param {AuthedBase<void>} base base
  */
 async function handler(base: AuthedBase<void>) {
-  // session tokenをDBから削除
-  await deleteSessionBySessionToken(await base.db(), base.sessionToken);
-
-  base.clearCookie(config.sessionCookieName, config.sessionCookieOptions());
+  await base.logout();
 }
 
 export default authHandlerWrapper(handler, 'GET');

--- a/pages/api/oauth/login/cateirusso.ts
+++ b/pages/api/oauth/login/cateirusso.ts
@@ -30,6 +30,8 @@ async function handler(base: Base<void>) {
   const user = await ca.login();
 
   await base.newLogin(user);
+
+  base.res.redirect('/hello');
 }
 
 export default handlerWrapper(handler, 'GET');

--- a/pages/hello.tsx
+++ b/pages/hello.tsx
@@ -1,0 +1,12 @@
+import HelloComponents from '../components/Hello';
+import Require from '../components/Session/Require';
+
+const Hello = () => {
+  return (
+    <Require path="/" loginRequire={true}>
+      <HelloComponents />
+    </Require>
+  );
+};
+
+export default Hello;

--- a/pages/oauth-login.tsx
+++ b/pages/oauth-login.tsx
@@ -4,7 +4,7 @@ import Require from '../components/Session/Require';
 const LoginOauth = () => {
   return (
     <Require path="/" loginRequire={false}>
-      <Center>
+      <Center h="80vh">
         <Link href="/api/oauth/cateirusso">
           <Button as="p">ログイン</Button>
         </Link>

--- a/pages/oauth-login.tsx
+++ b/pages/oauth-login.tsx
@@ -1,13 +1,16 @@
 import {Button, Center, Link} from '@chakra-ui/react';
+import Require from '../components/Session/Require';
 
-const Test = () => {
+const LoginOauth = () => {
   return (
-    <Center>
-      <Link href="/api/oauth/cateirusso">
-        <Button as="p">ログイン</Button>
-      </Link>
-    </Center>
+    <Require path="/" loginRequire={false}>
+      <Center>
+        <Link href="/api/oauth/cateirusso">
+          <Button as="p">ログイン</Button>
+        </Link>
+      </Center>
+    </Require>
   );
 };
 
-export default Test;
+export default LoginOauth;

--- a/src/base/authedBase.ts
+++ b/src/base/authedBase.ts
@@ -93,6 +93,7 @@ class AuthedBase<T> extends Base<T> {
   public clearSessionCookies() {
     this.clearCookie(config.sessionCookieName, config.sessionCookieOptions());
     this.clearCookie(config.refreshCookieName, config.refreshCookieOptions());
+    this.clearCookie(config.otherCookieName, config.otherCookieOptions());
   }
 
   public async logout() {

--- a/src/base/base.ts
+++ b/src/base/base.ts
@@ -360,10 +360,20 @@ class Base<T> {
   public async newLogin(user: User) {
     const session = await createSession(await this.db(), user.id);
 
+    if (typeof session.refresh_token === 'undefined') {
+      throw new ApiError(500, 'refresh_token is empty');
+    }
+
     this.setCookie(
       config.sessionCookieName,
       session.session_token,
       config.sessionCookieOptions()
+    );
+
+    this.setCookie(
+      config.refreshCookieName,
+      session.refresh_token,
+      config.refreshCookieOptions()
     );
   }
 

--- a/src/base/base.ts
+++ b/src/base/base.ts
@@ -40,6 +40,9 @@ class Base<T> {
   private cookies: string[];
   private postBody?: ParsedUrlQuery;
 
+  protected sessionToken?: string;
+  protected refreshToken?: string;
+
   constructor(req: NextApiRequest, res: NextApiResponse<T>) {
     this.req = req;
     this.res = res;
@@ -363,6 +366,9 @@ class Base<T> {
     if (typeof session.refresh_token === 'undefined') {
       throw new ApiError(500, 'refresh_token is empty');
     }
+
+    this.sessionToken = session.session_token;
+    this.refreshToken = session.refresh_token;
 
     this.setCookie(
       config.sessionCookieName,

--- a/src/base/base.ts
+++ b/src/base/base.ts
@@ -382,14 +382,11 @@ class Base<T> {
       config.refreshCookieOptions()
     );
 
-    const options = {
-      s: true,
-      a: user.is_admin,
-    };
+    const options = 'true';
 
     this.setCookie(
       config.otherCookieName,
-      JSON.stringify(options),
+      options,
       config.otherCookieOptions()
     );
   }

--- a/src/base/base.ts
+++ b/src/base/base.ts
@@ -32,6 +32,8 @@ class Base<T> {
   public req: NextApiRequest;
   public res: NextApiResponse;
 
+  public status: number;
+
   private _db?: Connection;
 
   private contentType: ParsedMediaType;
@@ -52,6 +54,10 @@ class Base<T> {
     this.userAgent = this.parseUA();
 
     this.cookies = [];
+
+    // デフォルトは200を返す
+    // ApiErrorでthrowした場合は別
+    this.status = 200;
   }
 
   /**

--- a/src/base/base.ts
+++ b/src/base/base.ts
@@ -381,6 +381,17 @@ class Base<T> {
       session.refresh_token,
       config.refreshCookieOptions()
     );
+
+    const options = {
+      s: true,
+      a: user.is_admin,
+    };
+
+    this.setCookie(
+      config.otherCookieName,
+      JSON.stringify(options),
+      config.otherCookieOptions()
+    );
   }
 
   /**

--- a/src/base/handlerWrapper.ts
+++ b/src/base/handlerWrapper.ts
@@ -23,6 +23,7 @@ export const handlerWrapper =
     }
 
     await base.end();
+    res.status(base.status);
     res.end();
   };
 
@@ -48,5 +49,6 @@ export const authHandlerWrapper =
     }
 
     await authBase.end();
+    res.status(authBase.status);
     res.end();
   };

--- a/src/models/session.ts
+++ b/src/models/session.ts
@@ -1,5 +1,6 @@
 export interface SessionModel {
   session_token: string;
+  refresh_token?: string;
   date: Date;
   period_date: Date;
   user_id: number;
@@ -11,11 +12,18 @@ export class Session implements SessionModel {
   readonly period_date: Date;
   readonly user_id: number;
 
+  // 上書き可能にしておく
+  public refresh_token?: string;
+
   constructor(row: SessionModel) {
     this.session_token = row.session_token;
     this.date = new Date(row.date);
     this.period_date = new Date(row.period_date);
     this.user_id = row.user_id;
+
+    if (row.refresh_token && row.refresh_token !== null) {
+      this.refresh_token = row.refresh_token;
+    }
   }
 
   /**

--- a/src/services/session.ts
+++ b/src/services/session.ts
@@ -126,8 +126,8 @@ export async function createSession(
   db: Connection,
   userId: number
 ): Promise<Session> {
-  const sessionToken = randomText(64);
-  const refreshToken = randomText(64);
+  const sessionToken = randomText(config.sessionTokenLen);
+  const refreshToken = randomText(config.refreshTokenLen);
 
   // session tokenを追加する
   await createSessionSpecifyToken(

--- a/src/services/session.ts
+++ b/src/services/session.ts
@@ -1,9 +1,9 @@
-import {randomBytes} from 'crypto';
 import sql, {select, gte, insert, delete as sqlDelete} from 'mysql-bricks';
 import {Connection, RowDataPacket} from 'mysql2/promise';
 import {ApiError} from 'next/dist/server/api-utils';
 import config from '../../config';
 import {Session, SessionModel} from '../models/session';
+import {randomText} from '../utils/random';
 
 /**
  * Session TokenからSessionを取得する
@@ -32,6 +32,90 @@ export async function findSessionBySessionToken(
 }
 
 /**
+ * Refresh tokenからSessionを取得する
+ *
+ * @param {Connection} db - database
+ * @param {string} token - refresh token
+ */
+export async function findSessionByRefreshToken(
+  db: Connection,
+  token: string
+): Promise<Session | null> {
+  const query = select('*')
+    .from('session')
+    .where(
+      sql.eq(
+        'session_token',
+        select('session_token')
+          .from('refresh')
+          .where({refresh_token: token})
+          .and(gte('period_date', sql('now()')))
+          .limit(1)
+      )
+    )
+    .and(gte('period_date', sql('now()')))
+    .limit(1)
+    .toParams({placeholder: '?'});
+
+  const [row] = await db.query<RowDataPacket[]>(query.text, query.values);
+
+  if (row.length === 0) {
+    return null;
+  }
+
+  return new Session(row[0] as SessionModel);
+}
+
+/**
+ * refresh Tokenからrefreshを取得する
+ *
+ * @param {Connection} db - database
+ * @param {string} token - session token
+ */
+export async function findRefreshByRefreshToken(db: Connection, token: string) {
+  const query = select('*')
+    .from('refresh')
+    .where({refresh_token: token})
+    .and(gte('period_date', sql('now()')))
+    .limit(1)
+    .toParams({placeholder: '?'});
+
+  const [row] = await db.query<RowDataPacket[]>(query.text, query.values);
+
+  if (row.length === 0) {
+    return null;
+  }
+
+  return new Session(row[0] as SessionModel);
+}
+
+/**
+ * refresh tokenからsession tokenを取得する
+ *
+ * @param {Connection} db - database
+ * @param {string} refreshToken - refresh token
+ */
+export async function findSessionTokenByRefreshToken(
+  db: Connection,
+  refreshToken: string
+): Promise<string | null> {
+  const query = select('session_token')
+    .from('refresh')
+    .where({refresh_token: refreshToken})
+    .and(gte('period_date', sql('now()')))
+    .limit(1)
+    .toParams({placeholder: '?'});
+
+  const [row] = await db.query<RowDataPacket[]>(query.text, query.values);
+
+  if (row.length === 0) {
+    return null;
+  }
+
+  return row[0].session_token;
+}
+
+/**
  * user idを指定してセッション情報を保存する
  * 有効期限は1週間
  *
@@ -42,11 +126,57 @@ export async function createSession(
   db: Connection,
   userId: number
 ): Promise<Session> {
-  const sessionToken = randomBytes(128).toString('hex');
+  const sessionToken = randomText(64);
+  const refreshToken = randomText(64);
 
-  return createSessionSpecifyToken(
+  // session tokenを追加する
+  await createSessionSpecifyToken(
     db,
     sessionToken,
+    config.sessionPeriodDay,
+    userId
+  );
+
+  // refresh tokenを追加する
+  await createRefreshSpecifyToken(
+    db,
+    refreshToken,
+    sessionToken,
+    config.sessionPeriodDay,
+    userId
+  );
+
+  // refresh token経由でsessionを取得する
+  const session = await findSessionByRefreshToken(db, refreshToken);
+
+  if (!session) {
+    throw new ApiError(500, 'no insert session');
+  }
+
+  session.refresh_token = refreshToken;
+
+  return session;
+}
+
+/**
+ * refreshTokenを使用してユーザ情報を取得します。
+ * sessionTokenの有効期限が切れている前提であり、トークンを更新します。
+ *
+ * @param {Connection} db - database
+ * @param {string} refreshToken - refresh token
+ * @param {number} userId - user id
+ */
+export async function updateSessionTokenByRefreshToken(
+  db: Connection,
+  refreshToken: string,
+  userId: number
+) {
+  const newSessionToken = randomText(64);
+
+  // session tokenを追加する
+  await createSessionSpecifyToken(
+    db,
+    newSessionToken,
     config.sessionPeriodDay,
     userId
   );
@@ -74,17 +204,37 @@ export async function createSessionSpecifyToken(
   }).toParams({placeholder: '?'});
 
   await db.query(query.text, query.values);
-
-  const session = await findSessionBySessionToken(db, sessionToken);
-
-  if (!session) {
-    throw new ApiError(500, 'no insert session');
-  }
-
-  return session;
 }
 
 /**
+ * refresh_tokenを指定して新しいレコードを作成する
+ *
+ * @param {Connection} db - database
+ * @param {string} refreshToken - リフレッシュトークン
+ * @param {string} sessionToken - session token
+ * @param {number} periodDay - 有効期限（日）
+ * @param {number} userId - user id
+ */
+export async function createRefreshSpecifyToken(
+  db: Connection,
+  refreshToken: string,
+  sessionToken: string,
+  periodDay: number,
+  userId: number
+) {
+  const query = insert('refresh', {
+    refresh_token: refreshToken,
+    session_token: sessionToken,
+    date: sql('NOW()'),
+    period_date: sql('DATE_ADD(NOW(), INTERVAL ? DAY)', periodDay),
+    user_id: userId,
+  }).toParams({placeholder: '?'});
+
+  await db.query(query.text, query.values);
+}
+
+/**
+ * session tokenからSessionを削除
  *
  * @param {Connection} db - database
  * @param {string} sessionToken - session token
@@ -94,6 +244,38 @@ export async function deleteSessionBySessionToken(
   sessionToken: string
 ) {
   const query = sqlDelete('session')
+    .where({session_token: sessionToken})
+    .toParams({placeholder: '?'});
+  await db.query<RowDataPacket[]>(query.text, query.values);
+}
+
+/**
+ * refresh tokenからRefreshを削除
+ *
+ * @param {Connection} db - database
+ * @param {string} refreshToken - refresh token
+ */
+export async function deleteRefreshByRefreshToken(
+  db: Connection,
+  refreshToken: string
+) {
+  const query = sqlDelete('refresh')
+    .where({refresh_token: refreshToken})
+    .toParams({placeholder: '?'});
+  await db.query<RowDataPacket[]>(query.text, query.values);
+}
+
+/**
+ * session tokenからRefreshを削除
+ *
+ * @param {Connection} db - database
+ * @param {string} sessionToken - session token
+ */
+export async function deleteRefreshBySessionToken(
+  db: Connection,
+  sessionToken: string
+) {
+  const query = sqlDelete('refresh')
     .where({session_token: sessionToken})
     .toParams({placeholder: '?'});
   await db.query<RowDataPacket[]>(query.text, query.values);

--- a/src/services/session.ts
+++ b/src/services/session.ts
@@ -142,7 +142,7 @@ export async function createSession(
     db,
     refreshToken,
     sessionToken,
-    config.sessionPeriodDay,
+    config.refreshPeriodDay,
     userId
   );
 

--- a/src/tests/models.ts
+++ b/src/tests/models.ts
@@ -59,6 +59,7 @@ export const createSessionModel = (
 
   return {
     session_token: options?.session_token || randomText(128),
+    refresh_token: options?.refresh_token,
     date: options?.date || now,
     period_date: options?.period_date || period,
     user_id: options?.user_id || randomInt(100000),

--- a/src/tests/models.ts
+++ b/src/tests/models.ts
@@ -2,6 +2,7 @@ import {randomBytes, randomInt} from 'crypto';
 import {CertModel} from '../models/cret';
 import {SessionModel} from '../models/session';
 import {UserModel} from '../models/user';
+import {randomText} from '../utils/random';
 
 /**
  * 参加日時を作成する
@@ -27,7 +28,7 @@ export function createUserModel(option?: Partial<UserModel>): UserModel {
   const newUser: UserModel = {
     id: option?.id || randomInt(10000), // 上書きされる
     display_name: option?.display_name || null,
-    mail: option?.mail || `${randomBytes(32).toString('hex')}@example.com`,
+    mail: option?.mail || `${randomText(32)}@example.com`,
     profile: option?.profile || null,
     user_name:
       option?.user_name ||
@@ -57,7 +58,7 @@ export const createSessionModel = (
   period.setDate(period.getDate() + 7);
 
   return {
-    session_token: options?.session_token || randomBytes(128).toString('hex'),
+    session_token: options?.session_token || randomText(128),
     date: options?.date || now,
     period_date: options?.period_date || period,
     user_id: options?.user_id || randomInt(100000),

--- a/src/tests/user.ts
+++ b/src/tests/user.ts
@@ -9,6 +9,7 @@ import User, {UserModel} from '../models/user';
 import {setCert} from '../services/cert';
 import {createSession} from '../services/session';
 import {createTestUser} from '../services/user';
+import {randomText} from '../utils/random';
 import {createUserModel} from './models';
 import {createCertModel} from './models';
 
@@ -35,7 +36,7 @@ export class TestUser {
 
     this.certModel = createCertModel({
       user_id: this.user?.id,
-      cateiru_sso_id: randomBytes(32).toString('hex'),
+      cateiru_sso_id: randomText(32),
     });
 
     await setCert(db, this.certModel);
@@ -46,7 +47,7 @@ export class TestUser {
       throw new Error('user is undefined');
     }
 
-    this.password = randomBytes(32).toString('hex');
+    this.password = randomText(32);
 
     this.certModel = createCertModel({
       user_id: this.user?.id,

--- a/src/tests/user.ts
+++ b/src/tests/user.ts
@@ -1,4 +1,3 @@
-import {randomBytes} from 'crypto';
 import argon2 from 'argon2';
 import {serialize} from 'cookie';
 import {Connection} from 'mysql2/promise';

--- a/src/tests/user.ts
+++ b/src/tests/user.ts
@@ -87,4 +87,16 @@ export class TestUser {
 
     return serialize(config.sessionCookieName, this.session.session_token);
   }
+
+  get refreshCookie() {
+    if (!this.session || typeof this.session.refresh_token === 'undefined') {
+      throw new Error('no session');
+    }
+
+    return serialize(config.refreshCookieName, this.session.refresh_token);
+  }
+
+  get cookie() {
+    return `${this.sessionCookie}; ${this.refreshCookie}`;
+  }
 }

--- a/src/utils/random.ts
+++ b/src/utils/random.ts
@@ -1,0 +1,10 @@
+import {randomBytes} from 'crypto';
+
+/**
+ * ランダムな文字列を生成する
+ *
+ * @param {number} size - 文字数
+ * @returns {string} - ランダム文字列
+ */
+export const randomText = (size: number): string =>
+  randomBytes(size).reduce((p, i) => p + (i % 36).toString(36), '');

--- a/tests/admin/noraQuestion.test.ts
+++ b/tests/admin/noraQuestion.test.ts
@@ -62,7 +62,7 @@ describe('noraQuestion', () => {
       handler: get,
       requestPatcher: async req => {
         req.headers = {
-          cookie: user.sessionCookie,
+          cookie: user.cookie,
         };
       },
       test: async ({fetch}) => {
@@ -82,7 +82,7 @@ describe('noraQuestion', () => {
       handler: get,
       requestPatcher: async req => {
         req.headers = {
-          cookie: normalUser.sessionCookie,
+          cookie: normalUser.cookie,
         };
       },
       test: async ({fetch}) => {
@@ -110,7 +110,7 @@ describe('noraQuestion', () => {
       handler: get,
       requestPatcher: async req => {
         req.headers = {
-          cookie: user.sessionCookie,
+          cookie: user.cookie,
         };
       },
       url: '/?limit=2',
@@ -132,7 +132,7 @@ describe('noraQuestion', () => {
       handler: post,
       requestPatcher: async req => {
         req.headers = {
-          cookie: user.sessionCookie,
+          cookie: user.cookie,
           'content-type': 'application/json',
         };
       },
@@ -165,7 +165,7 @@ describe('noraQuestion', () => {
       handler: post,
       requestPatcher: async req => {
         req.headers = {
-          cookie: normalUser.sessionCookie,
+          cookie: normalUser.cookie,
         };
       },
       test: async ({fetch}) => {
@@ -182,7 +182,7 @@ describe('noraQuestion', () => {
       handler: post,
       requestPatcher: async req => {
         req.headers = {
-          cookie: user.sessionCookie,
+          cookie: user.cookie,
           'content-type': 'application/json',
         };
       },
@@ -207,7 +207,7 @@ describe('noraQuestion', () => {
       handler: post,
       requestPatcher: async req => {
         req.headers = {
-          cookie: user.sessionCookie,
+          cookie: user.cookie,
           'content-type': 'application/json',
         };
       },
@@ -235,7 +235,7 @@ describe('noraQuestion', () => {
       handler: post,
       requestPatcher: async req => {
         req.headers = {
-          cookie: user.sessionCookie,
+          cookie: user.cookie,
           'content-type': 'application/json',
         };
       },
@@ -276,7 +276,7 @@ describe('noraQuestion', () => {
       handler: put,
       requestPatcher: async req => {
         req.headers = {
-          cookie: user.sessionCookie,
+          cookie: user.cookie,
           'content-type': 'application/json',
         };
       },
@@ -318,7 +318,7 @@ describe('noraQuestion', () => {
       handler: put,
       requestPatcher: async req => {
         req.headers = {
-          cookie: normalUser.sessionCookie,
+          cookie: normalUser.cookie,
         };
       },
       test: async ({fetch}) => {
@@ -347,7 +347,7 @@ describe('noraQuestion', () => {
       handler: put,
       requestPatcher: async req => {
         req.headers = {
-          cookie: user.sessionCookie,
+          cookie: user.cookie,
           'content-type': 'application/json',
         };
       },
@@ -398,7 +398,7 @@ describe('noraQuestion', () => {
       handler: _delete,
       requestPatcher: async req => {
         req.headers = {
-          cookie: user.sessionCookie,
+          cookie: user.cookie,
         };
       },
       url: `/?id=${question.id}`,
@@ -420,7 +420,7 @@ describe('noraQuestion', () => {
       handler: _delete,
       requestPatcher: async req => {
         req.headers = {
-          cookie: normalUser.sessionCookie,
+          cookie: normalUser.cookie,
         };
       },
       test: async ({fetch}) => {
@@ -437,7 +437,7 @@ describe('noraQuestion', () => {
       handler: _delete,
       requestPatcher: async req => {
         req.headers = {
-          cookie: user.sessionCookie,
+          cookie: user.cookie,
         };
       },
       url: `/?id=${randomInt(1000)}`,

--- a/tests/base/authedBase.test.ts
+++ b/tests/base/authedBase.test.ts
@@ -1,4 +1,3 @@
-import {randomBytes} from 'crypto';
 import {serialize} from 'cookie';
 import mysql from 'mysql2/promise';
 import {testApiHandler} from 'next-test-api-route-handler';
@@ -6,6 +5,7 @@ import config from '../../config';
 import AuthedBase from '../../src/base/authedBase';
 import {authHandlerWrapper} from '../../src/base/handlerWrapper';
 import {TestUser} from '../../src/tests/user';
+import {randomText} from '../../src/utils/random';
 
 describe('login', () => {
   let db: mysql.Connection;
@@ -91,7 +91,7 @@ describe('login', () => {
         req.headers = {
           cookie: serialize(
             config.sessionCookieName,
-            randomBytes(128).toString('hex'),
+            randomText(128),
             config.sessionCookieOptions()
           ),
         };

--- a/tests/base/authedBase.test.ts
+++ b/tests/base/authedBase.test.ts
@@ -16,6 +16,9 @@ describe('login', () => {
     await db.connect();
 
     await user.create(db);
+  });
+
+  beforeEach(async () => {
     await user.addSession(db);
   });
 
@@ -146,6 +149,24 @@ describe('login', () => {
       test: async ({fetch}) => {
         const res = await fetch();
         expect(res.status).toBe(200);
+
+        let sessionToken = '';
+        let refreshToken = '';
+
+        for (const c of res.cookies) {
+          if (typeof c[config.sessionCookieName] === 'string') {
+            sessionToken = c[config.sessionCookieName];
+          } else if (typeof c[config.refreshCookieName] === 'string') {
+            refreshToken = c[config.refreshCookieName];
+          }
+        }
+
+        // Tokenは更新される
+        expect(sessionToken).not.toBe('');
+        expect(refreshToken).not.toBe('');
+
+        expect(sessionToken).not.toBe(user.session?.session_token);
+        expect(refreshToken).not.toBe(user.session?.refresh_token);
       },
     });
   });

--- a/tests/base/base.test.ts
+++ b/tests/base/base.test.ts
@@ -1,4 +1,3 @@
-import exp from 'constants';
 import {URL} from 'url';
 import {serialize} from 'cookie';
 import mysql from 'mysql2/promise';

--- a/tests/base/base.test.ts
+++ b/tests/base/base.test.ts
@@ -1,3 +1,4 @@
+import exp from 'constants';
 import {URL} from 'url';
 import {serialize} from 'cookie';
 import mysql from 'mysql2/promise';
@@ -6,6 +7,7 @@ import {ApiError} from 'next/dist/server/api-utils';
 import config from '../../config';
 import Base, {Device} from '../../src/base/base';
 import {handlerWrapper} from '../../src/base/handlerWrapper';
+import {findSessionTokenByRefreshToken} from '../../src/services/session';
 import {findUserBySessionToken} from '../../src/services/user';
 import {TestUser} from '../../src/tests/user';
 
@@ -580,7 +582,7 @@ describe('newLogin', () => {
     await connection.end();
   });
 
-  test('新規でログインするとsession tokenがcookieにセットされる', async () => {
+  test('新規でログインするとtokenがcookieにセットされる', async () => {
     expect.hasAssertions();
 
     let userId = NaN;
@@ -605,11 +607,29 @@ describe('newLogin', () => {
         const res = await fetch();
         expect(res.status).toBe(200);
 
-        const session = res.cookies[0][config.sessionCookieName];
+        console.log(res.cookies);
+
+        let session = '';
+        let refresh = '';
+
+        for (const c of res.cookies) {
+          if (typeof c[config.sessionCookieName] === 'string') {
+            session = c[config.sessionCookieName];
+          } else if (typeof c[config.refreshCookieName] === 'string') {
+            refresh = c[config.refreshCookieName];
+          }
+        }
 
         const user = await findUserBySessionToken(connection, session);
 
         expect(user?.id).toBe(userId);
+
+        const sessionToken = await findSessionTokenByRefreshToken(
+          connection,
+          refresh
+        );
+
+        expect(sessionToken).toBe(session);
       },
     });
   });

--- a/tests/createAccont.test.ts
+++ b/tests/createAccont.test.ts
@@ -1,4 +1,3 @@
-import {randomBytes} from 'crypto';
 import mysql from 'mysql2/promise';
 import config from '../config';
 import {

--- a/tests/createAccont.test.ts
+++ b/tests/createAccont.test.ts
@@ -9,6 +9,7 @@ import {findCertByUserID} from '../src/services/cert';
 import {findUserByUserID} from '../src/services/user';
 import {createUserModel} from '../src/tests/models';
 import {TestUser} from '../src/tests/user';
+import {randomText} from '../src/utils/random';
 
 describe('cateiruSSO', () => {
   let db: mysql.Connection;
@@ -31,7 +32,7 @@ describe('cateiruSSO', () => {
       email: userModel.mail,
       role: '',
       picture: 'https://example.com',
-      id: randomBytes(32).toString('hex'),
+      id: randomText(32),
     };
 
     const ca = new CreateAccountBySSO(db, data);
@@ -81,7 +82,7 @@ describe('CreateAccountByPassword', () => {
 
   test('新規作成', async () => {
     const dummy = createUserModel();
-    const password = randomBytes(32).toString('hex');
+    const password = randomText(32);
 
     const ca = new CreateAccountByPassword(
       dummy.user_name,
@@ -110,7 +111,7 @@ describe('CreateAccountByPassword', () => {
 
     const mail = user.user?.mail || '';
     const dummy = createUserModel();
-    const password = randomBytes(32).toString('hex');
+    const password = randomText(32);
 
     const ca = new CreateAccountByPassword(
       dummy.user_name,
@@ -131,7 +132,7 @@ describe('CreateAccountByPassword', () => {
 
     const userName = user.user?.user_name || '';
     const dummy = createUserModel();
-    const password = randomBytes(32).toString('hex');
+    const password = randomText(32);
 
     const ca = new CreateAccountByPassword(
       userName,

--- a/tests/models/cret.test.ts
+++ b/tests/models/cret.test.ts
@@ -1,4 +1,3 @@
-import {randomBytes} from 'crypto';
 import argon2 from 'argon2';
 import Cert from '../../src/models/cret';
 import {randomText} from '../../src/utils/random';

--- a/tests/models/cret.test.ts
+++ b/tests/models/cret.test.ts
@@ -1,11 +1,12 @@
 import {randomBytes} from 'crypto';
 import argon2 from 'argon2';
 import Cert from '../../src/models/cret';
+import {randomText} from '../../src/utils/random';
 
 describe('cert', () => {
   test('equalCateiruSSO', () => {
-    const id1 = randomBytes(32).toString('hex');
-    const id2 = randomBytes(32).toString('hex');
+    const id1 = randomText(32);
+    const id2 = randomText(32);
 
     const cert1 = new Cert({
       user_id: 1,
@@ -18,8 +19,8 @@ describe('cert', () => {
   });
 
   test('equalPassword', async () => {
-    const pw1 = randomBytes(32).toString('hex');
-    const pw2 = randomBytes(32).toString('hex');
+    const pw1 = randomText(32);
+    const pw2 = randomText(32);
 
     const cert1 = new Cert({
       user_id: 1,

--- a/tests/models/session.test.ts
+++ b/tests/models/session.test.ts
@@ -1,5 +1,6 @@
 import {randomBytes, randomInt} from 'crypto';
 import {Session} from '../../src/models/session';
+import {randomText} from '../../src/utils/random';
 
 describe('isPeriod', () => {
   const now = new Date(Date.now());
@@ -12,7 +13,7 @@ describe('isPeriod', () => {
 
   test('有効期限内の場合はfalse', () => {
     const session = new Session({
-      session_token: randomBytes(32).toString('hex'),
+      session_token: randomText(32),
       date: now,
       period_date: onHourDate,
       user_id: randomInt(10),
@@ -23,7 +24,7 @@ describe('isPeriod', () => {
 
   test('有効期限切れの場合はtrue', () => {
     const session = new Session({
-      session_token: randomBytes(32).toString('hex'),
+      session_token: randomText(32),
       date: now,
       period_date: onDayAgoDate,
       user_id: randomInt(10),

--- a/tests/models/session.test.ts
+++ b/tests/models/session.test.ts
@@ -1,4 +1,4 @@
-import {randomBytes, randomInt} from 'crypto';
+import {randomInt} from 'crypto';
 import {Session} from '../../src/models/session';
 import {randomText} from '../../src/utils/random';
 

--- a/tests/pages/api/create/password.test.ts
+++ b/tests/pages/api/create/password.test.ts
@@ -5,6 +5,7 @@ import config from '../../../../config';
 import createPasswordHandler from '../../../../pages/api/create/password';
 import {findUserBySessionToken} from '../../../../src/services/user';
 import {createUserModel} from '../../../../src/tests/models';
+import {randomText} from '../../../../src/utils/random';
 
 describe('create', () => {
   let db: mysql.Connection;
@@ -22,7 +23,7 @@ describe('create', () => {
     expect.hasAssertions();
 
     const user = createUserModel({age: 20});
-    const password = randomBytes(50).toString('hex');
+    const password = randomText(50);
 
     await testApiHandler({
       handler: createPasswordHandler,
@@ -54,7 +55,7 @@ describe('create', () => {
     expect.hasAssertions();
 
     const user = createUserModel({age: 20});
-    const password = randomBytes(100).toString('hex');
+    const password = randomText(100);
 
     await testApiHandler({
       handler: createPasswordHandler,
@@ -78,7 +79,7 @@ describe('create', () => {
     expect.hasAssertions();
 
     const user = createUserModel({age: 20});
-    const password = randomBytes(100).toString('hex');
+    const password = randomText(100);
 
     await testApiHandler({
       handler: createPasswordHandler,

--- a/tests/pages/api/create/password.test.ts
+++ b/tests/pages/api/create/password.test.ts
@@ -1,4 +1,3 @@
-import {randomBytes} from 'crypto';
 import mysql from 'mysql2/promise';
 import {testApiHandler} from 'next-test-api-route-handler';
 import config from '../../../../config';

--- a/tests/service/cert.test.ts
+++ b/tests/service/cert.test.ts
@@ -1,4 +1,3 @@
-import {randomBytes} from 'crypto';
 import mysql from 'mysql2/promise';
 import config from '../../config';
 import {findCertByUserID, setCert} from '../../src/services/cert';

--- a/tests/service/cert.test.ts
+++ b/tests/service/cert.test.ts
@@ -3,6 +3,7 @@ import mysql from 'mysql2/promise';
 import config from '../../config';
 import {findCertByUserID, setCert} from '../../src/services/cert';
 import {createCertModel} from '../../src/tests/models';
+import {randomText} from '../../src/utils/random';
 
 describe('setCert', () => {
   let connection: mysql.Connection;
@@ -17,7 +18,7 @@ describe('setCert', () => {
   });
 
   test('ssoだけ', async () => {
-    const ssoId = randomBytes(32).toString('hex');
+    const ssoId = randomText(32);
 
     const certModel = createCertModel({cateiru_sso_id: ssoId});
 
@@ -31,7 +32,7 @@ describe('setCert', () => {
   });
 
   test('passwordだけ', async () => {
-    const pw = randomBytes(32).toString('hex');
+    const pw = randomText(32);
 
     const certModel = createCertModel({password: pw});
 
@@ -45,8 +46,8 @@ describe('setCert', () => {
   });
 
   test('ssoとpassword', async () => {
-    const pw = randomBytes(32).toString('hex');
-    const ssoId = randomBytes(32).toString('hex');
+    const pw = randomText(32);
+    const ssoId = randomText(32);
 
     const certModel = createCertModel({password: pw, cateiru_sso_id: ssoId});
 

--- a/tests/service/session.test.ts
+++ b/tests/service/session.test.ts
@@ -1,12 +1,19 @@
-import {randomBytes, randomInt} from 'crypto';
-import mysql from 'mysql2/promise';
+import {randomInt} from 'crypto';
+import mysql, {RowDataPacket} from 'mysql2/promise';
 import config from '../../config';
 import {
   createSession,
   findSessionBySessionToken,
   deleteSessionBySessionToken,
   createSessionSpecifyToken,
+  findSessionByRefreshToken,
+  createRefreshSpecifyToken,
+  findRefreshByRefreshToken,
+  findSessionTokenByRefreshToken,
+  deleteRefreshByRefreshToken,
+  deleteRefreshBySessionToken,
 } from '../../src/services/session';
+import {createSessionModel} from '../../src/tests/models';
 import {randomText} from '../../src/utils/random';
 
 describe('session', () => {
@@ -21,54 +28,218 @@ describe('session', () => {
     await db.end();
   });
 
-  test('作成、取得', async () => {
+  test('createSession', async () => {
     const session = await createSession(db, randomInt(10000));
 
-    const dbSession = await findSessionBySessionToken(
-      db,
+    const [row] = await db.query<RowDataPacket[]>(
+      'SELECT * FROM session WHERE session_token = ?',
       session.session_token
     );
 
-    expect(dbSession?.user_id).toBe(session.user_id);
+    expect(row.length).toBe(1);
   });
 
-  test('作成できる', async () => {
-    const token = randomText(128);
+  test('findSessionBySessionToken', async () => {
+    const s = createSessionModel();
+
+    await db.query(
+      `INSERT INTO session(
+      session_token,
+      date,
+      period_date,
+      user_id
+    ) VALUES (?, NOW(), DATE_ADD(NOW(), INTERVAL ? DAY), ?)`,
+      [s.session_token, '7', s.user_id]
+    );
+
+    const session = await findSessionBySessionToken(db, s.session_token);
+
+    expect(session?.user_id).toBe(s.user_id);
+  });
+
+  test('findRefreshByRefreshToken', async () => {
+    const s = createSessionModel();
+    const r = randomText(64);
+
+    await db.query(
+      `INSERT INTO refresh(
+      refresh_token,
+      session_token,
+      date,
+      period_date,
+      user_id
+    ) VALUES (?, ?, NOW(), DATE_ADD(NOW(), INTERVAL ? DAY), ?)`,
+      [r, s.session_token, '7', s.user_id]
+    );
+
+    const session = await findRefreshByRefreshToken(db, r);
+
+    expect(session?.user_id).toBe(s.user_id);
+  });
+
+  test('findSessionByRefreshToken', async () => {
+    const s = createSessionModel();
+    const r = randomText(64);
+
+    await db.query(
+      `INSERT INTO session(
+      session_token,
+      date,
+      period_date,
+      user_id
+    ) VALUES (?, NOW(), DATE_ADD(NOW(), INTERVAL ? DAY), ?)`,
+      [s.session_token, '7', s.user_id]
+    );
+
+    await db.query(
+      `INSERT INTO refresh(
+      refresh_token,
+      session_token,
+      date,
+      period_date,
+      user_id
+    ) VALUES (?, ?, NOW(), DATE_ADD(NOW(), INTERVAL ? DAY), ?)`,
+      [r, s.session_token, '7', s.user_id]
+    );
+
+    const session = await findSessionByRefreshToken(db, r);
+
+    expect(session?.user_id).toBe(s.user_id);
+  });
+
+  test('findSessionTokenByRefreshToken', async () => {
+    const s = createSessionModel();
+    const r = randomText(64);
+
+    await db.query(
+      `INSERT INTO refresh(
+      refresh_token,
+      session_token,
+      date,
+      period_date,
+      user_id
+    ) VALUES (?, ?, NOW(), DATE_ADD(NOW(), INTERVAL ? DAY), ?)`,
+      [r, s.session_token, '7', s.user_id]
+    );
+
+    const sessionToken = await findSessionTokenByRefreshToken(db, r);
+
+    expect(sessionToken).toBe(s.session_token);
+  });
+
+  test('sessionを作成できる', async () => {
+    const token = randomText(64);
     const periodDay = 1;
     const userId = randomInt(10000);
 
-    const session = await createSessionSpecifyToken(
-      db,
-      token,
-      periodDay,
-      userId
-    );
+    await createSessionSpecifyToken(db, token, periodDay, userId);
 
-    expect(session.user_id).toBe(userId);
+    const session = await findSessionBySessionToken(db, token);
 
-    const now = new Date(Date.now());
+    expect(session).not.toBeNull();
+    if (session) {
+      expect(session.user_id).toBe(userId);
 
-    // 時間をみる: hourのみ
-    expect(session.date.getHours()).toBe(now.getHours());
-    // period dateは+1日なので時間は同じはず
-    expect(session.period_date.getHours()).toBe(now.getHours());
+      const now = new Date(Date.now());
 
-    // 1日進める
-    now.setDate(now.getDate() + 1);
-    expect(session.period_date.getDate()).toBe(now.getDate());
+      // 時間をみる: hourのみ
+      expect(session.date.getHours()).toBe(now.getHours());
+      // period dateは+1日なので時間は同じはず
+      expect(session.period_date.getHours()).toBe(now.getHours());
+
+      // 1日進める
+      now.setDate(now.getDate() + 1);
+      expect(session.period_date.getDate()).toBe(now.getDate());
+    }
   });
 
-  test('削除できる', async () => {
-    const session = await createSession(db, randomInt(10000));
+  test('refreshを作成できる', async () => {
+    const token = randomText(64);
+    const sessionToken = randomText(64);
+    const periodDay = 1;
+    const userId = randomInt(10000);
 
-    const sessionToken = session.session_token;
+    await createRefreshSpecifyToken(db, token, sessionToken, periodDay, userId);
 
-    await deleteSessionBySessionToken(db, sessionToken);
+    const session = await findRefreshByRefreshToken(db, token);
 
-    const dbSession = await findSessionBySessionToken(
-      db,
-      session.session_token
+    expect(session).not.toBeNull();
+    if (session) {
+      expect(session.user_id).toBe(userId);
+
+      const now = new Date(Date.now());
+
+      // 時間をみる: hourのみ
+      expect(session.date.getHours()).toBe(now.getHours());
+      // period dateは+1日なので時間は同じはず
+      expect(session.period_date.getHours()).toBe(now.getHours());
+
+      // 1日進める
+      now.setDate(now.getDate() + 1);
+      expect(session.period_date.getDate()).toBe(now.getDate());
+    }
+  });
+
+  test('session tokenでSessionを削除できる', async () => {
+    const s = createSessionModel();
+
+    await db.query(
+      `INSERT INTO session(
+      session_token,
+      date,
+      period_date,
+      user_id
+    ) VALUES (?, NOW(), DATE_ADD(NOW(), INTERVAL ? DAY), ?)`,
+      [s.session_token, '7', s.user_id]
     );
+
+    await deleteSessionBySessionToken(db, s.session_token);
+
+    const dbSession = await findSessionBySessionToken(db, s.session_token);
+
+    expect(dbSession).toBeNull();
+  });
+
+  test('refresh tokenでRefreshを削除できる', async () => {
+    const s = createSessionModel();
+    const r = randomText(64);
+
+    await db.query(
+      `INSERT INTO refresh(
+      refresh_token,
+      session_token,
+      date,
+      period_date,
+      user_id
+    ) VALUES (?, ?, NOW(), DATE_ADD(NOW(), INTERVAL ? DAY), ?)`,
+      [r, s.session_token, '7', s.user_id]
+    );
+
+    await deleteRefreshByRefreshToken(db, r);
+
+    const dbSession = await findRefreshByRefreshToken(db, r);
+
+    expect(dbSession).toBeNull();
+  });
+
+  test('session tokenでRefreshを削除', async () => {
+    const s = createSessionModel();
+    const r = randomText(64);
+
+    await db.query(
+      `INSERT INTO refresh(
+      refresh_token,
+      session_token,
+      date,
+      period_date,
+      user_id
+    ) VALUES (?, ?, NOW(), DATE_ADD(NOW(), INTERVAL ? DAY), ?)`,
+      [r, s.session_token, '7', s.user_id]
+    );
+
+    await deleteRefreshBySessionToken(db, s.session_token);
+
+    const dbSession = await findRefreshByRefreshToken(db, r);
 
     expect(dbSession).toBeNull();
   });

--- a/tests/service/session.test.ts
+++ b/tests/service/session.test.ts
@@ -7,6 +7,7 @@ import {
   deleteSessionBySessionToken,
   createSessionSpecifyToken,
 } from '../../src/services/session';
+import {randomText} from '../../src/utils/random';
 
 describe('session', () => {
   let db: mysql.Connection;
@@ -32,7 +33,7 @@ describe('session', () => {
   });
 
   test('作成できる', async () => {
-    const token = randomBytes(128).toString('hex');
+    const token = randomText(128);
     const periodDay = 1;
     const userId = randomInt(10000);
 

--- a/tests/service/user.test.ts
+++ b/tests/service/user.test.ts
@@ -16,6 +16,7 @@ import {
 } from '../../src/services/user';
 import {createCertModel, createUserModel} from '../../src/tests/models';
 import {TestUser} from '../../src/tests/user';
+import {randomText} from '../../src/utils/random';
 
 describe('getUser', () => {
   let connection: mysql.Connection;
@@ -116,9 +117,7 @@ describe('findUserByCateiruSSO', () => {
   });
 
   test('certが存在しない場合はnullが返る', async () => {
-    expect(
-      await findUserByCateiruSSO(connection, randomBytes(32).toString('hex'))
-    ).toBeNull();
+    expect(await findUserByCateiruSSO(connection, randomText(32))).toBeNull();
   });
 
   test('ssoが存在する場合は返る', async () => {
@@ -127,7 +126,7 @@ describe('findUserByCateiruSSO', () => {
 
     const cert = createCertModel({
       user_id: user.id,
-      cateiru_sso_id: randomBytes(32).toString('hex'),
+      cateiru_sso_id: randomText(32),
     });
     await setCert(connection, cert);
 
@@ -171,10 +170,7 @@ describe('findUserBySessionToken', () => {
     const user = new TestUser();
     await user.create(connection);
 
-    const dbUser = await findUserBySessionToken(
-      connection,
-      randomBytes(128).toString('hex')
-    );
+    const dbUser = await findUserBySessionToken(connection, randomText(128));
 
     expect(dbUser).toBeNull();
   });
@@ -207,10 +203,7 @@ describe('findUserByMail', () => {
     const user = new TestUser();
     await user.create(connection);
 
-    const dbUser = await findUserByMail(
-      connection,
-      randomBytes(128).toString('hex')
-    );
+    const dbUser = await findUserByMail(connection, randomText(128));
 
     expect(dbUser).toBeNull();
   });
@@ -246,10 +239,7 @@ describe('findUserByUserName', () => {
     const user = new TestUser();
     await user.create(connection);
 
-    const dbUser = await findUserByUserName(
-      connection,
-      randomBytes(128).toString('hex')
-    );
+    const dbUser = await findUserByUserName(connection, randomText(128));
 
     expect(dbUser).toBeNull();
   });

--- a/tests/service/user.test.ts
+++ b/tests/service/user.test.ts
@@ -1,4 +1,3 @@
-import {randomBytes} from 'crypto';
 import mysql from 'mysql2/promise';
 import config from '../../config';
 import {setCert} from '../../src/services/cert';

--- a/tests/syntax/check.test.ts
+++ b/tests/syntax/check.test.ts
@@ -7,6 +7,7 @@ import {
   checkUserName,
   checkProfile,
 } from '../../src/syntax/check';
+import {randomText} from '../../src/utils/random';
 
 describe('checkUserName', () => {
   test('正しい', () => {
@@ -24,7 +25,7 @@ describe('checkUserName', () => {
   });
 
   test('16文字より大きいとエラー', () => {
-    const name = randomBytes(32).toString('hex');
+    const name = randomText(32);
 
     expect(() => checkUserName(name)).toThrow();
   });
@@ -76,7 +77,7 @@ describe('checkAge', () => {
 
 describe('checkPW', () => {
   test('正しい', () => {
-    const pw = randomBytes(32).toString('hex');
+    const pw = randomText(32);
 
     expect(() => checkPW(pw)).not.toThrow();
   });
@@ -98,7 +99,7 @@ describe('checkDisplayName', () => {
   });
 
   test('フォーマットが正しくないとエラー', () => {
-    const names = ['@@@asogo4p', '', randomBytes(64).toString('hex')];
+    const names = ['@@@asogo4p', '', randomText(64)];
 
     for (const n of names) {
       expect(() => checkDisplayName(n)).toThrow();
@@ -108,7 +109,7 @@ describe('checkDisplayName', () => {
 
 describe('checkProfile', () => {
   test('正しい', () => {
-    const p = ['a', randomBytes(32).toString('hex')];
+    const p = ['a', randomText(32)];
 
     for (const n of p) {
       expect(() => checkProfile(n)).not.toThrow();
@@ -116,7 +117,7 @@ describe('checkProfile', () => {
   });
 
   test('128文字制限', () => {
-    const p = randomBytes(128).toString('hex');
+    const p = randomText(128);
 
     expect(() => checkProfile(p)).toThrow();
   });

--- a/tests/syntax/check.test.ts
+++ b/tests/syntax/check.test.ts
@@ -1,4 +1,3 @@
-import {randomBytes} from 'crypto';
 import {
   checkAge,
   checkDisplayName,

--- a/tests/user/config/configPut.test.ts
+++ b/tests/user/config/configPut.test.ts
@@ -8,6 +8,7 @@ import {findUserByUserID} from '../../../src/services/user';
 import {createUserModel} from '../../../src/tests/models';
 import {TestUser} from '../../../src/tests/user';
 import {setConfigHandler} from '../../../src/user/config/configPut';
+import {randomText} from '../../../src/utils/random';
 
 describe('更新', () => {
   let db: mysql.Connection;
@@ -27,8 +28,8 @@ describe('更新', () => {
     await u.addSession(db);
 
     const newUser = createUserModel({
-      display_name: randomBytes(10).toString('hex'),
-      profile: randomBytes(20).toString('hex'),
+      display_name: randomText(10),
+      profile: randomText(20),
       age: 100,
       gender: Gender.Female,
     });
@@ -72,7 +73,7 @@ describe('更新', () => {
     await u.addSession(db);
 
     const newUser = createUserModel({
-      profile: randomBytes(20).toString('hex'),
+      profile: randomText(20),
     });
 
     expect.hasAssertions();

--- a/tests/user/config/configPut.test.ts
+++ b/tests/user/config/configPut.test.ts
@@ -1,4 +1,3 @@
-import {randomBytes} from 'crypto';
 import mysql from 'mysql2/promise';
 import {testApiHandler} from 'next-test-api-route-handler';
 import config from '../../../config';

--- a/tests/user/config/configPut.test.ts
+++ b/tests/user/config/configPut.test.ts
@@ -41,7 +41,7 @@ describe('更新', () => {
       handler: h,
       requestPatcher: async req => {
         req.headers = {
-          cookie: u.sessionCookie,
+          cookie: u.cookie,
           'content-type': 'application/x-www-form-urlencoded',
         };
       },
@@ -83,7 +83,7 @@ describe('更新', () => {
       handler: h,
       requestPatcher: async req => {
         req.headers = {
-          cookie: u.sessionCookie,
+          cookie: u.cookie,
           'content-type': 'application/x-www-form-urlencoded',
         };
       },

--- a/utils/atom.ts
+++ b/utils/atom.ts
@@ -1,0 +1,7 @@
+import {atom} from 'recoil';
+import {User} from './types';
+
+export const UserState = atom<User | null | undefined>({
+  key: 'User',
+  default: undefined,
+});

--- a/utils/cookie.ts
+++ b/utils/cookie.ts
@@ -1,0 +1,7 @@
+/**
+ * @param {string} key - cookie key
+ * @returns {string} - cookie value
+ */
+export default function cookieValue(key: string): string {
+  return ((document.cookie + ';').match(key + '=([^¥S;]*)') || [])[1];
+}

--- a/utils/types.ts
+++ b/utils/types.ts
@@ -1,0 +1,11 @@
+export interface User {
+  display_name: string;
+  mail: string;
+  profile: string;
+  user_name: string;
+  age: number;
+  gender: number;
+  is_admin: boolean;
+  avatar_url: string;
+  join_date: Date;
+}


### PR DESCRIPTION
- issue:

## 🔧 修正点

- バックエンド
  - `refresh_token`を追加した
    - これにより、セッション切れで強制ログアウトされてしまう問題を解決した
  - jsで見れるようのcookieを追加 

- フロント
  - アクセスした際にcookieが設定されている場合、`/api/user/me`からユーザ情報を取得するようなロジック追加
  - `<Require path="/" loginRequire={true} ></Require>`というようなコンポーネントを作成
    - `loginRequire`がtrueの場合はその子の要素はログインしていないと表示されない。ログインしていない場合はpathの値にリダイレクトする。

## ✅ 自己チェック

- [x] 動作確認ができているか
- [x] 新しく追加したメソッドにユニットテストを追加しているか
- [x] 静的解析、テストは成功しているか
- [x] `Files changed`を自分で確認してミスがないか

## 📸 スクリーンショット（オプション）

## ⚠️ レビュー時に注意して欲しいこと（オプション）

## 🗣️ 補足など（オプション）
