### PR TITLE
アカウント削除APIの追加

### DIFF
--- a/pages/api/create/password.ts
+++ b/pages/api/create/password.ts
@@ -1,6 +1,6 @@
 import Base from '../../../src/base/base';
 import {handlerWrapper} from '../../../src/base/handlerWrapper';
-import {CreateAccountByPassword} from '../../../src/createAccount';
+import {CreateAccountByPassword} from '../../../src/user/createAccount';
 
 /**
  * パスワードを使用してアカウントを新規作成する

--- a/pages/api/oauth/login/cateirusso.ts
+++ b/pages/api/oauth/login/cateirusso.ts
@@ -1,8 +1,8 @@
 import {ApiError} from 'next/dist/server/api-utils';
 import Base from '../../../../src/base/base';
 import {handlerWrapper} from '../../../../src/base/handlerWrapper';
-import {CreateAccountBySSO} from '../../../../src/createAccount';
 import {JWT} from '../../../../src/oauth/cateirusso/jwt';
+import {CreateAccountBySSO} from '../../../../src/user/createAccount';
 
 /**
  * Cateiru SSOのログインリンクへリダイレクトする

--- a/pages/api/user.ts
+++ b/pages/api/user.ts
@@ -1,0 +1,6 @@
+import {switchMethod} from '../../src/base/switchMethod';
+import deleteUser from '../../src/user/delete';
+
+export default switchMethod({
+  DELETE: deleteUser,
+});

--- a/src/services/cert.ts
+++ b/src/services/cert.ts
@@ -1,4 +1,4 @@
-import {select, insert} from 'mysql-bricks';
+import sql, {select, insert} from 'mysql-bricks';
 import type {Connection, RowDataPacket} from 'mysql2/promise';
 import {ApiError} from 'next/dist/server/api-utils';
 import Cert, {CertModel} from '../models/cret';
@@ -49,4 +49,19 @@ export async function findCertByUserID(
   }
 
   return new Cert(row[0] as CertModel);
+}
+
+/**
+ * Certを削除する
+ *
+ * @param {Connection} db - database
+ * @param {number} userId - User ID
+ */
+export async function deleteCertById(db: Connection, userId: number) {
+  const query = sql
+    .delete('cert')
+    .where('user_id', userId)
+    .toParams({placeholder: '?'});
+
+  await db.query(query.text, query.values);
 }

--- a/src/services/user.ts
+++ b/src/services/user.ts
@@ -318,3 +318,15 @@ export async function updateUser(
 
   await db.query(query.text, query.values);
 }
+
+/**
+ * userを削除する
+ *
+ * @param {Connection} db - database
+ * @param {number} id - ユーザID
+ */
+export async function deleteUserByID(db: Connection, id: number) {
+  const query = sql.delete('user').where('id', id).toParams({placeholder: '?'});
+
+  await db.query(query.text, query.values);
+}

--- a/src/user/createAccount.ts
+++ b/src/user/createAccount.ts
@@ -2,18 +2,18 @@ import argon2 from 'argon2';
 import {JwtPayload} from 'jsonwebtoken';
 import {Connection} from 'mysql2/promise';
 import {ApiError} from 'next/dist/server/api-utils';
-import {Gender, gender as pg} from './models/common';
-import {CertModel} from './models/cret';
-import User from './models/user';
-import {setCert} from './services/cert';
+import {Gender, gender as pg} from './../models/common';
+import {CertModel} from './../models/cret';
+import User from './../models/user';
+import {setCert} from './../services/cert';
 import {
   createUserPW,
   createUserSSO,
   findUserByCateiruSSO,
   findUserByUserID,
   findUserByUserNameAndMail,
-} from './services/user';
-import * as check from './syntax/check';
+} from './../services/user';
+import * as check from './../syntax/check';
 
 export class CreateAccountBySSO {
   private displayName: string;

--- a/src/user/delete.ts
+++ b/src/user/delete.ts
@@ -1,0 +1,19 @@
+import AuthedBase from '../base/authedBase';
+import {authHandlerWrapper} from '../base/handlerWrapper';
+import {deleteCertById} from '../services/cert';
+import {deleteUserByID} from '../services/user';
+
+/**
+ * ユーザを削除する
+ *
+ * @param {AuthedBase} base - base
+ */
+async function userDeleteHandler(base: AuthedBase<void>) {
+  // sessionを削除する
+  await base.logout();
+
+  await deleteCertById(await base.db(), base.user.id);
+  await deleteUserByID(await base.db(), base.user.id);
+}
+
+export default authHandlerWrapper(userDeleteHandler);

--- a/tests/service/cert.test.ts
+++ b/tests/service/cert.test.ts
@@ -1,6 +1,10 @@
-import mysql from 'mysql2/promise';
+import mysql, {RowDataPacket} from 'mysql2/promise';
 import config from '../../config';
-import {findCertByUserID, setCert} from '../../src/services/cert';
+import {
+  deleteCertById,
+  findCertByUserID,
+  setCert,
+} from '../../src/services/cert';
 import {createCertModel} from '../../src/tests/models';
 import {randomText} from '../../src/utils/random';
 
@@ -57,5 +61,29 @@ describe('setCert', () => {
     expect(cert.user_id).toBe(certModel.user_id);
     expect(cert.cateiru_sso_id).toBe(ssoId);
     expect(cert.password).toBe(pw);
+  });
+
+  test('certを削除する', async () => {
+    const pw = randomText(32);
+
+    const certModel = createCertModel({password: pw});
+
+    await setCert(connection, certModel);
+
+    let [rows] = await connection.query<RowDataPacket[]>(
+      'SELECT * FROM cert WHERE user_id = ?',
+      certModel.user_id
+    );
+
+    expect(rows.length).toBe(1);
+
+    await deleteCertById(connection, certModel.user_id);
+
+    [rows] = await connection.query<RowDataPacket[]>(
+      'SELECT * FROM cert WHERE user_id = ?',
+      certModel.user_id
+    );
+
+    expect(rows.length).toBe(0);
   });
 });

--- a/tests/service/user.test.ts
+++ b/tests/service/user.test.ts
@@ -1,4 +1,4 @@
-import mysql from 'mysql2/promise';
+import mysql, {RowDataPacket} from 'mysql2/promise';
 import config from '../../config';
 import {setCert} from '../../src/services/cert';
 import {
@@ -12,6 +12,7 @@ import {
   createUserPW,
   findUserByUserNameAndMail,
   updateUser,
+  deleteUserByID,
 } from '../../src/services/user';
 import {createCertModel, createUserModel} from '../../src/tests/models';
 import {TestUser} from '../../src/tests/user';
@@ -368,5 +369,19 @@ describe('updateUser', () => {
         user_name: user2.user?.user_name || '',
       });
     }).rejects.toThrow();
+  });
+
+  test('idから削除できる', async () => {
+    const user = new TestUser();
+    await user.create(db);
+
+    await deleteUserByID(db, user.user?.id || NaN);
+
+    const [rows] = await db.query<RowDataPacket[]>(
+      'SELECT * FROM user WHERE id = ?',
+      user.user?.id || NaN
+    );
+
+    expect(rows.length).toBe(0);
   });
 });

--- a/tests/user/createAccont.test.ts
+++ b/tests/user/createAccont.test.ts
@@ -1,14 +1,14 @@
 import mysql from 'mysql2/promise';
-import config from '../config';
+import config from '../../config';
+import {findCertByUserID} from '../../src/services/cert';
+import {findUserByUserID} from '../../src/services/user';
+import {createUserModel} from '../../src/tests/models';
+import {TestUser} from '../../src/tests/user';
 import {
   CreateAccountByPassword,
   CreateAccountBySSO,
-} from '../src/createAccount';
-import {findCertByUserID} from '../src/services/cert';
-import {findUserByUserID} from '../src/services/user';
-import {createUserModel} from '../src/tests/models';
-import {TestUser} from '../src/tests/user';
-import {randomText} from '../src/utils/random';
+} from '../../src/user/createAccount';
+import {randomText} from '../../src/utils/random';
 
 describe('cateiruSSO', () => {
   let db: mysql.Connection;

--- a/tests/user/delete.test.ts
+++ b/tests/user/delete.test.ts
@@ -1,0 +1,85 @@
+import mysql, {RowDataPacket} from 'mysql2/promise';
+import {testApiHandler} from 'next-test-api-route-handler';
+import config from '../../config';
+import {findSessionTokenByRefreshToken} from '../../src/services/session';
+import {TestUser} from '../../src/tests/user';
+import deleteUserHandler from '../../src/user/delete';
+
+describe('アカウント削除', () => {
+  let db: mysql.Connection;
+
+  beforeAll(async () => {
+    db = await mysql.createConnection(config.db);
+    await db.connect();
+  });
+
+  afterAll(async () => {
+    await db.end();
+  });
+
+  test('削除できる', async () => {
+    expect.hasAssertions();
+
+    const user = new TestUser();
+
+    await user.create(db);
+    await user.loginFromPassword(db);
+    await user.addSession(db);
+
+    const [userRows] = await db.query<RowDataPacket[]>(
+      'SELECT * FROM user WHERE id = ?',
+      user.user?.id
+    );
+
+    expect(userRows.length).toBe(1);
+
+    const [certRows] = await db.query<RowDataPacket[]>(
+      'SELECT * FROM cert WHERE user_id = ?',
+      user.user?.id
+    );
+
+    expect(certRows.length).toBe(1);
+
+    const session = await findSessionTokenByRefreshToken(
+      db,
+      user.session?.refresh_token || ''
+    );
+
+    expect(session).not.toBeNull();
+
+    await testApiHandler({
+      handler: deleteUserHandler,
+      requestPatcher: async req => {
+        req.headers = {
+          cookie: user.cookie,
+        };
+      },
+      test: async ({fetch}) => {
+        const res = await fetch({method: 'DELETE'});
+
+        expect(res.status).toBe(200);
+
+        const [userRows] = await db.query<RowDataPacket[]>(
+          'SELECT * FROM user WHERE id = ?',
+          user.user?.id
+        );
+
+        expect(userRows.length).toBe(0);
+
+        const [certRows] = await db.query<RowDataPacket[]>(
+          'SELECT * FROM cert WHERE user_id = ?',
+          user.user?.id
+        );
+
+        expect(certRows.length).toBe(0);
+
+        const session = await findSessionTokenByRefreshToken(
+          db,
+          user.session?.refresh_token || ''
+        );
+
+        expect(session).toBeNull();
+      },
+    });
+  });
+});


### PR DESCRIPTION
- issue: resolved https://github.com/team-ful/noratomo/issues/19

## 🔧 修正点

アカウント削除するAPIエンドポイントを追加

`DELETE /api/user`

## ✅ 自己チェック

- [x] 動作確認ができているか
- [x] 新しく追加したメソッドにユニットテストを追加しているか
- [x] 静的解析、テストは成功しているか
- [x] `Files changed`を自分で確認してミスがないか

## 📸 スクリーンショット（オプション）

## ⚠️ レビュー時に注意して欲しいこと（オプション）

## 🗣️ 補足など（オプション）
