### PR TITLE
SSOログインでユーザ情報を変更していた場合noratomoのuserも更新する

### DIFF
--- a/pages/api/oauth/login/cateirusso.ts
+++ b/pages/api/oauth/login/cateirusso.ts
@@ -19,7 +19,9 @@ async function handler(base: Base<void>) {
 
   const code = base.getQuery('code');
   if (typeof code === 'undefined') {
-    throw new ApiError(400, 'code is not found');
+    // キャンセルしたりエラーだったりした場合はログインしないでホームにリダイレクトさせてしまう
+    base.res.redirect('/');
+    return;
   }
   const jwt = new JWT(code);
 

--- a/src/createAccount.ts
+++ b/src/createAccount.ts
@@ -12,6 +12,8 @@ import {
   findUserByCateiruSSO,
   findUserByUserID,
   findUserByUserNameAndMail,
+  UpdateOption,
+  updateUser,
 } from './services/user';
 import * as check from './syntax/check';
 
@@ -47,10 +49,37 @@ export class CreateAccountBySSO {
     const user = await findUserByCateiruSSO(this.db, this.ssoId);
 
     if (user) {
-      return user;
+      return await this.update(user.id);
     }
 
     return await this.createUser();
+  }
+
+  /**
+   * ユーザを更新する
+   *
+   * @param {number} id - user id
+   * @returns {Promise<User>} - user
+   */
+  private async update(id: number): Promise<User> {
+    const option: UpdateOption = {};
+
+    if (this.displayName) {
+      option['display_name'] = this.displayName;
+    }
+    if (this.mail) {
+      option['mail'] = this.mail;
+    }
+    if (this.isAdmin) {
+      option['is_admin'] = this.isAdmin;
+    }
+    if (this.avatarURL) {
+      option['avatar_url'] = this.avatarURL;
+    }
+
+    await updateUser(this.db, id, option);
+
+    return await findUserByUserID(this.db, id);
   }
 
   /**

--- a/src/services/user.ts
+++ b/src/services/user.ts
@@ -4,6 +4,17 @@ import {Connection, Pool, RowDataPacket} from 'mysql2/promise';
 import {Gender} from '../models/common';
 import User, {UserModel} from '../models/user';
 
+export interface UpdateOption {
+  display_name?: string | null;
+  mail?: string;
+  profile?: string | null;
+  user_name?: string;
+  age?: number;
+  gender?: Gender;
+  is_admin?: boolean;
+  avatar_url?: string;
+}
+
 /**
  * UserIDからユーザ情報を取得する
  *
@@ -291,25 +302,12 @@ export async function findUserByUserNameAndMail(
  *
  * @param {Connection} db - database
  * @param {number} id - ユーザID
- * @param {{}} option - option
- * @param {string | null} option.display_name - display name
- * @param {string} option.mail - メールアドレス
- * @param {string | null} option.profile - profile
- * @param {string} option.user_name - user name
- * @param {number} option.age - 年齢
- * @param {Gender} option.gender - 性別
+ * @param {UpdateOption} option - options
  */
 export async function updateUser(
   db: Connection,
   id: number,
-  option: {
-    display_name?: string | null;
-    mail?: string;
-    profile?: string | null;
-    user_name?: string;
-    age?: number;
-    gender?: Gender;
-  }
+  option: UpdateOption
 ) {
   const query = sql
     .update('user', option)

--- a/tests/service/user.test.ts
+++ b/tests/service/user.test.ts
@@ -1,5 +1,6 @@
 import mysql from 'mysql2/promise';
 import config from '../../config';
+import {Gender} from '../../src/models/common';
 import {setCert} from '../../src/services/cert';
 import {
   findUserByUserID,
@@ -335,6 +336,25 @@ describe('updateUser', () => {
     await db.end();
   });
 
+  test('メールアドレスを更新できる', async () => {
+    const user = new TestUser();
+    await user.create(db);
+
+    const u = await findUserByUserID(db, user.user?.id || NaN);
+
+    const newMail = `${randomText(10)}@example.com`;
+
+    await updateUser(db, u.id, {
+      mail: newMail,
+    });
+
+    const u1 = await findUserByUserID(db, user.user?.id || NaN);
+
+    expect(u1).not.toEqual(u);
+    expect(u1.mail).not.toBe(u.mail);
+    expect(u1.id).toBe(u.id);
+  });
+
   test('display_nameを更新できる', async () => {
     const user = new TestUser();
     await user.create(db);
@@ -351,6 +371,84 @@ describe('updateUser', () => {
 
     expect(u1).not.toEqual(u);
     expect(u1.display_name).not.toBe(u.display_name);
+    expect(u1.id).toBe(u.id);
+  });
+
+  test('user_nameを更新できる', async () => {
+    const user = new TestUser();
+    await user.create(db);
+
+    const u = await findUserByUserID(db, user.user?.id || NaN);
+
+    const newUserName = randomText(10);
+
+    await updateUser(db, u.id, {
+      user_name: newUserName,
+    });
+
+    const u1 = await findUserByUserID(db, user.user?.id || NaN);
+
+    expect(u1).not.toEqual(u);
+    expect(u1.user_name).not.toBe(u.user_name);
+    expect(u1.id).toBe(u.id);
+  });
+
+  test('genderを更新できる', async () => {
+    const user = new TestUser({gender: Gender.Male});
+    await user.create(db);
+
+    const u = await findUserByUserID(db, user.user?.id || NaN);
+
+    expect(u.gender).toBe(Gender.Male);
+
+    const newGender = Gender.Female;
+
+    await updateUser(db, u.id, {
+      gender: newGender,
+    });
+
+    const u1 = await findUserByUserID(db, user.user?.id || NaN);
+
+    expect(u1).not.toEqual(u);
+    expect(u1.gender).not.toBe(u.gender);
+    expect(u1.id).toBe(u.id);
+  });
+
+  test('is_adminを更新できる', async () => {
+    const user = new TestUser({is_admin: false});
+    await user.create(db);
+
+    const u = await findUserByUserID(db, user.user?.id || NaN);
+
+    const newAdmin = true;
+
+    await updateUser(db, u.id, {
+      is_admin: newAdmin,
+    });
+
+    const u1 = await findUserByUserID(db, user.user?.id || NaN);
+
+    expect(u1).not.toEqual(u);
+    expect(u1.is_admin).not.toBe(u.is_admin);
+    expect(u1.id).toBe(u.id);
+  });
+
+  test('avatarURLを更新できる', async () => {
+    const user = new TestUser({avatar_url: randomText(10)});
+    await user.create(db);
+
+    const u = await findUserByUserID(db, user.user?.id || NaN);
+
+    const newAvatarUrl = randomText(10);
+
+    await updateUser(db, u.id, {
+      avatar_url: newAvatarUrl,
+    });
+
+    const u1 = await findUserByUserID(db, user.user?.id || NaN);
+
+    expect(u1).not.toEqual(u);
+    expect(u1.avatar_url).not.toBe(u.avatar_url);
     expect(u1.id).toBe(u.id);
   });
 


### PR DESCRIPTION
- issue:

## 🔧 修正点

- SSOログインでユーザ情報を変更していた場合noratomoのuserも更新するように変更

## ✅ 自己チェック

- [x] 動作確認ができているか
- [x] 新しく追加したメソッドにユニットテストを追加しているか
- [x] 静的解析、テストは成功しているか
- [x] `Files changed`を自分で確認してミスがないか

## 📸 スクリーンショット（オプション）

## ⚠️ レビュー時に注意して欲しいこと（オプション）

## 🗣️ 補足など（オプション）
