### PR TITLE
ログイン履歴を保存するようにする

### DIFF
--- a/db/sql/001_schema.sql
+++ b/db/sql/001_schema.sql
@@ -30,7 +30,7 @@ CREATE TABLE IF NOT EXISTS `cert` (
 CREATE TABLE IF NOT EXISTS `login_history` (
     `id` INT UNSIGNED AUTO_INCREMENT NOT NULL,
     `user_id` INT UNSIGNED NOT NULL,
-    `ip_address` INT(10) UNSIGNED NOT NULL,
+    `ip_address` VARBINARY(16) NOT NULL,
     `device_name` VARCHAR(256),
     `os` VARCHAR(256),
     `is_phone` BOOLEAN,

--- a/db/sql/001_schema.sql
+++ b/db/sql/001_schema.sql
@@ -36,7 +36,7 @@ CREATE TABLE IF NOT EXISTS `login_history` (
     `is_phone` BOOLEAN,
     `is_tablet` BOOLEAN,
     `is_desktop` BOOLEAN,
-    `blowser_name` VARCHAR(256),
+    `browser_name` VARCHAR(256),
     `login_date` DATETIME NOT NULL,
     PRIMARY KEY (`id`)
 );

--- a/src/models/loginHistory.ts
+++ b/src/models/loginHistory.ts
@@ -9,7 +9,7 @@ export interface LoginHistoryModel {
   is_phone: boolean | null;
   is_tablet: boolean | null;
   is_desktop: boolean | null;
-  blowser_name: string | null;
+  browser_name: string | null;
   login_date: Date;
 }
 
@@ -22,7 +22,7 @@ class LoginHistory implements LoginHistoryModel {
   readonly is_phone: boolean | null;
   readonly is_tablet: boolean | null;
   readonly is_desktop: boolean | null;
-  readonly blowser_name: string | null;
+  readonly browser_name: string | null;
   readonly login_date: Date;
 
   constructor(init: {[key: string]: any}) {
@@ -37,7 +37,7 @@ class LoginHistory implements LoginHistoryModel {
     this.is_desktop = init.is_desktop;
     this.is_tablet = init.is_tablet;
 
-    this.blowser_name = init.blowser_name;
+    this.browser_name = init.browser_name;
     this.login_date = new Date(init.login_date);
   }
 

--- a/src/models/loginHistory.ts
+++ b/src/models/loginHistory.ts
@@ -1,0 +1,70 @@
+import {Device} from '../base/base';
+
+export interface LoginHistoryModel {
+  id: number;
+  user_id: number;
+  ip_address: string;
+  device_name: Device | null;
+  os: string | null;
+  is_phone: boolean | null;
+  is_tablet: boolean | null;
+  is_desktop: boolean | null;
+  blowser_name: string | null;
+  login_date: Date;
+}
+
+class LoginHistory implements LoginHistoryModel {
+  readonly id: number;
+  readonly user_id: number;
+  readonly ip_address: string;
+  readonly device_name: Device | null;
+  readonly os: string | null;
+  readonly is_phone: boolean | null;
+  readonly is_tablet: boolean | null;
+  readonly is_desktop: boolean | null;
+  readonly blowser_name: string | null;
+  readonly login_date: Date;
+
+  constructor(init: LoginHistoryModel) {
+    this.id = init.id;
+    this.user_id = init.user_id;
+
+    this.ip_address = init.ip_address;
+    this.device_name = this.parseDevice(init.device_name as string | null);
+    this.os = init.os;
+
+    this.is_phone = init.is_phone;
+    this.is_desktop = init.is_desktop;
+    this.is_tablet = init.is_tablet;
+
+    this.blowser_name = init.blowser_name;
+    this.login_date = new Date(init.login_date);
+  }
+
+  private parseDevice(d: string | null): Device | null {
+    if (d === null) {
+      return null;
+    }
+
+    switch (d) {
+      case 'Console':
+        return Device.Console;
+      case 'Mobile':
+        return Device.Mobile;
+      case 'Tablet':
+        return Device.Tablet;
+      case 'Desktop':
+        return Device.Desktop;
+      case 'SmartTV':
+        return Device.SmartTV;
+      case 'Wearable':
+        return Device.Wearable;
+      case 'Embedded':
+        return Device.Embedded;
+      default:
+        return Device.Desktop;
+    }
+  }
+}
+
+export default LoginHistory;

--- a/src/models/loginHistory.ts
+++ b/src/models/loginHistory.ts
@@ -29,7 +29,7 @@ class LoginHistory implements LoginHistoryModel {
     this.id = init.id;
     this.user_id = init.user_id;
 
-    this.ip_address = init["INET_NTOA(ip_address)"];
+    this.ip_address = init["INET6_NTOA(ip_address)"];
     this.device_name = this.parseDevice(init.device_name as string | null);
     this.os = init.os;
 

--- a/src/models/loginHistory.ts
+++ b/src/models/loginHistory.ts
@@ -29,7 +29,7 @@ class LoginHistory implements LoginHistoryModel {
     this.id = init.id;
     this.user_id = init.user_id;
 
-    this.ip_address = init["INET6_NTOA(ip_address)"];
+    this.ip_address = init['INET6_NTOA(ip_address)'];
     this.device_name = this.parseDevice(init.device_name as string | null);
     this.os = init.os;
 

--- a/src/models/loginHistory.ts
+++ b/src/models/loginHistory.ts
@@ -25,11 +25,11 @@ class LoginHistory implements LoginHistoryModel {
   readonly blowser_name: string | null;
   readonly login_date: Date;
 
-  constructor(init: LoginHistoryModel) {
+  constructor(init: {[key: string]: any}) {
     this.id = init.id;
     this.user_id = init.user_id;
 
-    this.ip_address = init.ip_address;
+    this.ip_address = init["INET_NTOA(ip_address)"];
     this.device_name = this.parseDevice(init.device_name as string | null);
     this.os = init.os;
 

--- a/src/services/loginHistory.ts
+++ b/src/services/loginHistory.ts
@@ -17,8 +17,8 @@ export async function findLoginHistoriesByUserID(
     .select([
       'id',
       'user_id',
-      // IPアドレスは`INET_ATON`使っている
-      sql('INET_NTOA(ip_address)'),
+      // IPアドレスは`INET6_ATON`使っている
+      sql('INET6_NTOA(ip_address)'),
       'device_name',
       'os',
       'is_phone',
@@ -68,7 +68,7 @@ export async function createLoginHistory(
   const query = sql
     .insert('login_history', {
       user_id: userID,
-      ip_address: sql('INET_ATON(?)', ip),
+      ip_address: sql('INET6_ATON(?)', ip),
       device_name: deviceName,
       os: os,
       is_phone: isPhone,

--- a/src/services/loginHistory.ts
+++ b/src/services/loginHistory.ts
@@ -1,0 +1,103 @@
+import sql from 'mysql-bricks';
+import {Connection, ResultSetHeader, RowDataPacket} from 'mysql2/promise';
+import {Device} from '../base/base';
+import LoginHistory from '../models/loginHistory';
+
+/**
+ * ユーザー名からログイン履歴を取得する
+ *
+ * @param {Connection} db - database
+ * @param {number} userID - user id
+ */
+export async function findLoginHistoriesByUserID(
+  db: Connection,
+  userID: number
+): Promise<LoginHistory[] | null> {
+  const query = sql
+    .select([
+      'id',
+      'user_id',
+      // IPアドレスは`INET_ATON`使っている
+      sql('INET_NTOA(ip_address)'),
+      'device_name',
+      'os',
+      'is_phone',
+      'is_tablet',
+      'is_desktop',
+      'blowser_name',
+      'login_date',
+    ])
+    .from('login_history')
+    .where('user_id', userID)
+    .toParams({placeholder: '?'});
+
+  const [rows] = await db.query<RowDataPacket[]>(query.text, query.values);
+
+  if (rows.length === 0) {
+    return null;
+  }
+
+  return rows.map(v => new LoginHistory(v));
+}
+
+/**
+ * ログイン履歴を追加する
+ *
+ * @param {Connection} db - database
+ * @param {number} userID - ユーザーID
+ * @param {string} ip - IP アドレス
+ * @param {Device} deviceName - デバイス名
+ * @param {string} os - OS名
+ * @param {boolean} isPhone - モバイル端末か
+ * @param {boolean} isTablet - タブレットか
+ * @param {boolean} isDesktop - デスクトップか
+ * @param {string} browserName - ブラウザ名
+ * @returns {number} - ログイン履歴のID
+ */
+export async function createLoginHistory(
+  db: Connection,
+  userID: number,
+  ip: string,
+  deviceName: Device,
+  os: string,
+  isPhone: boolean,
+  isTablet: boolean,
+  isDesktop: boolean,
+  browserName: string
+): Promise<number> {
+  const query = sql
+    .insert('login_history', {
+      user_id: userID,
+      ip_address: sql('INET_ATON(?)', ip),
+      device_name: deviceName,
+      os: os,
+      is_phone: isPhone,
+      is_tablet: isTablet,
+      is_desktop: isDesktop,
+      blowser_name: browserName,
+      login_date: sql('NOW()'),
+    })
+    .toParams({placeholder: '?'});
+
+  const [rows] = await db.query<ResultSetHeader>(query.text, query.values);
+
+  return rows.insertId;
+}
+
+/**
+ * 指定したユーザIDのログイン履歴をすべて削除する
+ *
+ * @param {Connection} db - database
+ * @param {number} userID - ユーザID
+ */
+export async function deleteLoginHistoryByUserID(
+  db: Connection,
+  userID: number
+) {
+  const query = sql
+    .delete('login_history')
+    .where('user_id', userID)
+    .toParams({placeholder: '?'});
+
+  await db.query(query.text, query.values);
+}

--- a/src/services/loginHistory.ts
+++ b/src/services/loginHistory.ts
@@ -24,7 +24,7 @@ export async function findLoginHistoriesByUserID(
       'is_phone',
       'is_tablet',
       'is_desktop',
-      'blowser_name',
+      'browser_name',
       'login_date',
     ])
     .from('login_history')
@@ -74,7 +74,7 @@ export async function createLoginHistory(
       is_phone: isPhone,
       is_tablet: isTablet,
       is_desktop: isDesktop,
-      blowser_name: browserName,
+      browser_name: browserName,
       login_date: sql('NOW()'),
     })
     .toParams({placeholder: '?'});

--- a/src/tests/models.ts
+++ b/src/tests/models.ts
@@ -107,7 +107,7 @@ export const createLoginHistoryModel = (
     is_phone: options?.is_phone || false,
     is_tablet: options?.is_tablet || false,
     is_desktop: options?.is_desktop || true,
-    blowser_name: options?.blowser_name || 'Chrome',
+    browser_name: options?.browser_name || 'Chrome',
     login_date: options?.login_date || loginDate,
   };
 };

--- a/src/tests/models.ts
+++ b/src/tests/models.ts
@@ -99,7 +99,7 @@ export const createLoginHistoryModel = (
     os: options?.os || 'Windows',
     is_phone: options?.is_phone || false,
     is_tablet: options?.is_tablet || false,
-    is_desktop: options?.is_desktop || false,
+    is_desktop: options?.is_desktop || true,
     blowser_name: options?.blowser_name || 'Chrome',
     login_date: options?.login_date || loginDate,
   };

--- a/src/tests/models.ts
+++ b/src/tests/models.ts
@@ -19,6 +19,13 @@ export function dbDate(d: Date): Date {
 }
 
 /**
+ * ユーザIDを作成する
+ *
+ * @returns {number} - ユーザID
+ */
+export const createUserID = () => randomInt(100000);
+
+/**
  * テスト用のダミーUserModelを作成する
  *
  * @param {Partial<UserModel>} option -カスタムするUserModel
@@ -28,7 +35,7 @@ export function createUserModel(option?: Partial<UserModel>): UserModel {
   const joinDate = dbDate(new Date(Date.now()));
 
   const newUser: UserModel = {
-    id: option?.id || randomInt(10000), // 上書きされる
+    id: option?.id || createUserID(), // 上書きされる
     display_name: option?.display_name || null,
     mail: option?.mail || `${randomText(32)}@example.com`,
     profile: option?.profile || null,
@@ -75,7 +82,7 @@ export const createSessionModel = (
  * @returns {CertModel} cert
  */
 export const createCertModel = (options?: Partial<CertModel>): CertModel => ({
-  user_id: options?.user_id || randomInt(1000000),
+  user_id: options?.user_id || createUserID(),
   cateiru_sso_id: options?.cateiru_sso_id || null,
   password: options?.password || null,
 });
@@ -93,7 +100,7 @@ export const createLoginHistoryModel = (
 
   return {
     id: options?.id || randomInt(1000000),
-    user_id: options?.user_id || randomInt(1000000),
+    user_id: options?.user_id || createUserID(),
     ip_address: options?.ip_address || '203.0.113.0', // 203.0.113.0はテスト用のIPアドレス
     device_name: options?.device_name || Device.Desktop,
     os: options?.os || 'Windows',

--- a/src/tests/models.ts
+++ b/src/tests/models.ts
@@ -1,5 +1,7 @@
 import {randomBytes, randomInt} from 'crypto';
+import {Device} from '../base/base';
 import {CertModel} from '../models/cret';
+import {LoginHistoryModel} from '../models/loginHistory';
 import {SessionModel} from '../models/session';
 import {UserModel} from '../models/user';
 import {randomText} from '../utils/random';
@@ -77,3 +79,28 @@ export const createCertModel = (options?: Partial<CertModel>): CertModel => ({
   cateiru_sso_id: options?.cateiru_sso_id || null,
   password: options?.password || null,
 });
+
+/**
+ * ダミーのログイン履歴オブジェクトを作成する
+ *
+ * @param {Partial<LoginHistoryModel>} options - オプション
+ * @returns {LoginHistoryModel} ログイン履歴
+ */
+export const createLoginHistoryModel = (
+  options?: Partial<LoginHistoryModel>
+): LoginHistoryModel => {
+  const loginDate = dbDate(new Date(Date.now()));
+
+  return {
+    id: options?.id || randomInt(1000000),
+    user_id: options?.user_id || randomInt(1000000),
+    ip_address: options?.ip_address || '203.0.113.0', // 203.0.113.0はテスト用のIPアドレス
+    device_name: options?.device_name || Device.Desktop,
+    os: options?.os || 'Windows',
+    is_phone: options?.is_phone || false,
+    is_tablet: options?.is_tablet || false,
+    is_desktop: options?.is_desktop || false,
+    blowser_name: options?.blowser_name || 'Chrome',
+    login_date: options?.login_date || loginDate,
+  };
+};

--- a/src/tests/user.ts
+++ b/src/tests/user.ts
@@ -75,7 +75,7 @@ export class TestUser {
       d.is_phone || false,
       d.is_tablet || false,
       d.is_desktop || false,
-      d.blowser_name || 'Chrome'
+      d.browser_name || 'Chrome'
     );
   }
 

--- a/src/tests/user.ts
+++ b/src/tests/user.ts
@@ -2,14 +2,16 @@ import argon2 from 'argon2';
 import {serialize} from 'cookie';
 import {Connection} from 'mysql2/promise';
 import config from '../../config';
+import {Device} from '../base/base';
 import {CertModel} from '../models/cret';
 import {Session} from '../models/session';
 import User, {UserModel} from '../models/user';
 import {setCert} from '../services/cert';
+import {createLoginHistory} from '../services/loginHistory';
 import {createSession} from '../services/session';
 import {createTestUser} from '../services/user';
 import {randomText} from '../utils/random';
-import {createUserModel} from './models';
+import {createLoginHistoryModel, createUserModel} from './models';
 import {createCertModel} from './models';
 
 export class TestUser {
@@ -62,6 +64,19 @@ export class TestUser {
     }
 
     this.session = await createSession(db, this.user.id);
+
+    const d = createLoginHistoryModel();
+    await createLoginHistory(
+      db,
+      this.user.id,
+      d.ip_address,
+      d.device_name || Device.Desktop,
+      d.os || '',
+      d.is_phone || false,
+      d.is_tablet || false,
+      d.is_desktop || false,
+      d.blowser_name || 'Chrome'
+    );
   }
 
   get cateiruSSOId() {

--- a/tests/base/authedBase.test.ts
+++ b/tests/base/authedBase.test.ts
@@ -4,6 +4,7 @@ import {testApiHandler} from 'next-test-api-route-handler';
 import config from '../../config';
 import AuthedBase from '../../src/base/authedBase';
 import {authHandlerWrapper} from '../../src/base/handlerWrapper';
+import {findLoginHistoriesByUserID} from '../../src/services/loginHistory';
 import {TestUser} from '../../src/tests/user';
 import {randomText} from '../../src/utils/random';
 
@@ -29,6 +30,11 @@ describe('login', () => {
   test('session-token, refresh-tokenどちらのcookieも設定されている場合、認証される', async () => {
     expect.hasAssertions();
 
+    const beforeLoginHistory = await findLoginHistoriesByUserID(
+      db,
+      user.user?.id || NaN
+    );
+
     const handler = async (base: AuthedBase<void>) => {
       const user = base.user;
 
@@ -48,12 +54,25 @@ describe('login', () => {
       test: async ({fetch}) => {
         const res = await fetch();
         expect(res.status).toBe(200);
+
+        const loginHistory = await findLoginHistoriesByUserID(
+          db,
+          user.user?.id || NaN
+        );
+
+        expect(loginHistory).not.toBeNull();
+        expect(loginHistory?.length).toBe(beforeLoginHistory?.length);
       },
     });
   });
 
   test('session-token cookieが設定されている場合、それを使用して認証される', async () => {
     expect.hasAssertions();
+
+    const beforeLoginHistory = await findLoginHistoriesByUserID(
+      db,
+      user.user?.id || NaN
+    );
 
     const handler = async (base: AuthedBase<void>) => {
       const user = base.user;
@@ -75,12 +94,25 @@ describe('login', () => {
       test: async ({fetch}) => {
         const res = await fetch();
         expect(res.status).toBe(200);
+
+        const loginHistory = await findLoginHistoriesByUserID(
+          db,
+          user.user?.id || NaN
+        );
+
+        expect(loginHistory).not.toBeNull();
+        expect(loginHistory?.length).toBe(beforeLoginHistory?.length);
       },
     });
   });
 
   test('refresh-token cookieが設定されている場合、それを使用して認証される', async () => {
     expect.hasAssertions();
+
+    const beforeLoginHistory = await findLoginHistoriesByUserID(
+      db,
+      user.user?.id || NaN
+    );
 
     const handler = async (base: AuthedBase<void>) => {
       const user = base.user;
@@ -119,12 +151,25 @@ describe('login', () => {
 
         expect(sessionToken).not.toBe(user.session?.session_token);
         expect(refreshToken).not.toBe(user.session?.refresh_token);
+
+        const loginHistory = await findLoginHistoriesByUserID(
+          db,
+          user.user?.id || NaN
+        );
+
+        expect(loginHistory).not.toBeNull();
+        expect(loginHistory?.length).not.toBe(beforeLoginHistory?.length);
       },
     });
   });
 
   test('session-token cookieが不正な場合はrefresh-tokenを使用してログインする', async () => {
     expect.hasAssertions();
+
+    const beforeLoginHistory = await findLoginHistoriesByUserID(
+      db,
+      user.user?.id || NaN
+    );
 
     const handler = async (base: AuthedBase<void>) => {
       const user = base.user;
@@ -167,6 +212,14 @@ describe('login', () => {
 
         expect(sessionToken).not.toBe(user.session?.session_token);
         expect(refreshToken).not.toBe(user.session?.refresh_token);
+
+        const loginHistory = await findLoginHistoriesByUserID(
+          db,
+          user.user?.id || NaN
+        );
+
+        expect(loginHistory).not.toBeNull();
+        expect(loginHistory?.length).not.toBe(beforeLoginHistory?.length);
       },
     });
   });

--- a/tests/base/base.test.ts
+++ b/tests/base/base.test.ts
@@ -6,6 +6,7 @@ import {ApiError} from 'next/dist/server/api-utils';
 import config from '../../config';
 import Base, {Device} from '../../src/base/base';
 import {handlerWrapper} from '../../src/base/handlerWrapper';
+import {findLoginHistoriesByUserID} from '../../src/services/loginHistory';
 import {findSessionTokenByRefreshToken} from '../../src/services/session';
 import {findUserBySessionToken} from '../../src/services/user';
 import {TestUser} from '../../src/tests/user';
@@ -629,6 +630,17 @@ describe('newLogin', () => {
         );
 
         expect(sessionToken).toBe(session);
+
+        const loginHistory = await findLoginHistoriesByUserID(
+          connection,
+          user?.id || NaN
+        );
+
+        expect(loginHistory).not.toBeNull();
+        if (loginHistory) {
+          expect(loginHistory.length).toBe(2); // TestUserでログイン履歴を保存しているため2
+          expect(loginHistory[0].device_name).toBe(Device.Desktop);
+        }
       },
     });
   });

--- a/tests/models/loginHistory.test.ts
+++ b/tests/models/loginHistory.test.ts
@@ -1,0 +1,15 @@
+import LoginHistory from '../../src/models/loginHistory';
+import {createLoginHistoryModel} from '../../src/tests/models';
+
+describe('loginHistory', () => {
+  test('作成できる', () => {
+    const loginHistory = createLoginHistoryModel();
+
+    const l = new LoginHistory(loginHistory);
+
+    expect(l.user_id).toBe(loginHistory.user_id);
+
+    expect(l.login_date).toEqual(loginHistory.login_date);
+    expect(l.device_name).toBe(loginHistory.device_name);
+  });
+});

--- a/tests/service/loginHistory.test.ts
+++ b/tests/service/loginHistory.test.ts
@@ -1,0 +1,155 @@
+import mysql, {RowDataPacket} from 'mysql2/promise';
+import config from '../../config';
+import {Device} from '../../src/base/base';
+import {
+  createLoginHistory,
+  deleteLoginHistoryByUserID,
+  findLoginHistoriesByUserID,
+} from '../../src/services/loginHistory';
+import {createLoginHistoryModel, createUserID} from '../../src/tests/models';
+
+describe('createLoginHistory', () => {
+  let db: mysql.Connection;
+
+  beforeAll(async () => {
+    db = await mysql.createConnection(config.db);
+    await db.connect();
+  });
+
+  afterAll(async () => {
+    await db.end();
+  });
+
+  test('作成できる', async () => {
+    const d = createLoginHistoryModel();
+
+    const id = await createLoginHistory(
+      db,
+      d.user_id,
+      d.ip_address,
+      d.device_name || Device.Desktop,
+      d.os || '',
+      d.is_phone || false,
+      d.is_tablet || false,
+      d.is_desktop || false,
+      d.blowser_name || ''
+    );
+
+    const [rows] = await db.query<RowDataPacket[]>(
+      'SELECT COUNT(*) FROM login_history WHERE id = ?',
+      id
+    );
+
+    expect(rows[0]['COUNT(*)']).toBe(1);
+  });
+
+  test('IPアドレスが正しく保存されている', async () => {
+    const d = createLoginHistoryModel();
+
+    const id = await createLoginHistory(
+      db,
+      d.user_id,
+      d.ip_address,
+      d.device_name || Device.Desktop,
+      d.os || '',
+      d.is_phone || false,
+      d.is_tablet || false,
+      d.is_desktop || false,
+      d.blowser_name || ''
+    );
+
+    const [rows] = await db.query<RowDataPacket[]>(
+      'SELECT INET_NTOA(ip_address) FROM login_history WHERE id = ?',
+      id
+    );
+
+    expect(rows[0]['INET_NTOA(ip_address)']).toBe(d.ip_address);
+  });
+});
+
+describe('findLoginHistoriesByUserID', () => {
+  let db: mysql.Connection;
+
+  beforeAll(async () => {
+    db = await mysql.createConnection(config.db);
+    await db.connect();
+  });
+
+  afterAll(async () => {
+    await db.end();
+  });
+
+  test('取得できる', async () => {
+    const d = createLoginHistoryModel();
+
+    await db.query(
+      `INSERT INTO login_history (
+      user_id,
+      ip_address,
+      device_name,
+      os,
+      login_date
+    ) VALUES (?, INET_ATON(?), ?, ?, NOW())`,
+      [d.user_id, d.ip_address, d.device_name, d.os]
+    );
+
+    const history = await findLoginHistoriesByUserID(db, d.user_id);
+
+    expect(history).not.toBeNull();
+    expect(history?.length).toBe(1);
+
+    if (history) {
+      expect(history[0].os).toBe(d.os);
+      expect(history[0].ip_address).toBe(d.ip_address);
+    }
+  });
+});
+
+describe('deleteLoginHistoryByUserID', () => {
+  let db: mysql.Connection;
+
+  beforeAll(async () => {
+    db = await mysql.createConnection(config.db);
+    await db.connect();
+  });
+
+  afterAll(async () => {
+    await db.end();
+  });
+
+  test('削除できる', async () => {
+    const userID = createUserID();
+
+    // ログイン履歴を3つ作成する
+    for (let i = 0; 3 > i; i++) {
+      const d = createLoginHistoryModel({user_id: userID});
+
+      await db.query(
+        `INSERT INTO login_history (
+        user_id,
+        ip_address,
+        device_name,
+        os,
+        login_date
+      ) VALUES (?, INET_ATON(?), ?, ?, NOW())`,
+        [d.user_id, d.ip_address, d.device_name, d.os]
+      );
+    }
+
+    let [rows] = await db.query<RowDataPacket[]>(
+      'SELECT COUNT(*) FROM login_history WHERE user_id = ?',
+      userID
+    );
+
+    expect(rows[0]['COUNT(*)']).toBe(3);
+
+    await deleteLoginHistoryByUserID(db, userID);
+
+    [rows] = await db.query<RowDataPacket[]>(
+      'SELECT COUNT(*) FROM login_history WHERE user_id = ?',
+      userID
+    );
+
+    expect(rows[0]['COUNT(*)']).toBe(0);
+  });
+});

--- a/tests/service/loginHistory.test.ts
+++ b/tests/service/loginHistory.test.ts
@@ -32,7 +32,7 @@ describe('createLoginHistory', () => {
       d.is_phone || false,
       d.is_tablet || false,
       d.is_desktop || false,
-      d.blowser_name || ''
+      d.browser_name || ''
     );
 
     const [rows] = await db.query<RowDataPacket[]>(
@@ -55,7 +55,7 @@ describe('createLoginHistory', () => {
       d.is_phone || false,
       d.is_tablet || false,
       d.is_desktop || false,
-      d.blowser_name || ''
+      d.browser_name || ''
     );
 
     const [rows] = await db.query<RowDataPacket[]>(
@@ -80,7 +80,7 @@ describe('createLoginHistory', () => {
       d.is_phone || false,
       d.is_tablet || false,
       d.is_desktop || false,
-      d.blowser_name || ''
+      d.browser_name || ''
     );
 
     const [rows] = await db.query<RowDataPacket[]>(

--- a/tests/service/loginHistory.test.ts
+++ b/tests/service/loginHistory.test.ts
@@ -59,11 +59,36 @@ describe('createLoginHistory', () => {
     );
 
     const [rows] = await db.query<RowDataPacket[]>(
-      'SELECT INET_NTOA(ip_address) FROM login_history WHERE id = ?',
+      'SELECT INET6_NTOA(ip_address) FROM login_history WHERE id = ?',
       id
     );
 
-    expect(rows[0]['INET_NTOA(ip_address)']).toBe(d.ip_address);
+    expect(rows[0]['INET6_NTOA(ip_address)']).toBe(d.ip_address);
+  });
+
+  test('IPv6のIPアドレスが正しく保存されている', async () => {
+    const d = createLoginHistoryModel({
+      ip_address: '2001:db8:ffff:ffff:ffff:ffff:ffff:ffff',
+    });
+
+    const id = await createLoginHistory(
+      db,
+      d.user_id,
+      d.ip_address,
+      d.device_name || Device.Desktop,
+      d.os || '',
+      d.is_phone || false,
+      d.is_tablet || false,
+      d.is_desktop || false,
+      d.blowser_name || ''
+    );
+
+    const [rows] = await db.query<RowDataPacket[]>(
+      'SELECT INET6_NTOA(ip_address) FROM login_history WHERE id = ?',
+      id
+    );
+
+    expect(rows[0]['INET6_NTOA(ip_address)']).toBe(d.ip_address);
   });
 });
 

--- a/tests/service/loginHistory.test.ts
+++ b/tests/service/loginHistory.test.ts
@@ -114,7 +114,7 @@ describe('findLoginHistoriesByUserID', () => {
       device_name,
       os,
       login_date
-    ) VALUES (?, INET_ATON(?), ?, ?, NOW())`,
+    ) VALUES (?, INET6_ATON(?), ?, ?, NOW())`,
       [d.user_id, d.ip_address, d.device_name, d.os]
     );
 


### PR DESCRIPTION
- issue: resolved https://github.com/team-ful/noratomo/issues/20

## 🔧 修正点

- 新しくログインしたとき
- セッショントークンの有効期限が切れており、リフレッシュトークンを使用して更新した場合

にIPアドレス、UA、日時をログイン履歴としてDBに保存する。

## ✅ 自己チェック

- [x] 動作確認ができているか
- [x] 新しく追加したメソッドにユニットテストを追加しているか
- [x] 静的解析、テストは成功しているか
- [x] `Files changed`を自分で確認してミスがないか

## 📸 スクリーンショット（オプション）

## ⚠️ レビュー時に注意して欲しいこと（オプション）

## 🗣️ 補足など（オプション）
