### PR TITLE
セッショントークンの有効期限をセッション間になる

### DIFF
--- a/config/environments/local.ts
+++ b/config/environments/local.ts
@@ -22,15 +22,10 @@ const config: Config = {
 
   sessionTokenLen: 64,
   sessionCookieName: 'noratomo-session',
-  sessionPeriodDay: 7,
+  sessionPeriodDay: 1,
   sessionCookieOptions: () => {
-    const date = new Date(Date.now());
-    date.setDate(date.getDate() + config.sessionPeriodDay);
-
     return {
       domain: LOCAL_URL,
-      expires: date,
-      maxAge: config.sessionPeriodDay * 86400,
       sameSite: 'strict',
       secure: false, // テスト用であるためfalse
       httpOnly: true,

--- a/config/environments/production.ts
+++ b/config/environments/production.ts
@@ -20,15 +20,10 @@ const config: Config = {
 
   sessionTokenLen: 64,
   sessionCookieName: 'noratomo-session',
-  sessionPeriodDay: 7,
+  sessionPeriodDay: 1,
   sessionCookieOptions: () => {
-    const date = new Date(Date.now());
-    date.setDate(date.getDate() + config.sessionPeriodDay);
-
     return {
       domain: 'noratomo.tdu.app',
-      expires: date,
-      maxAge: config.sessionPeriodDay * 86400,
       sameSite: 'strict',
       secure: true,
       httpOnly: true,

--- a/config/environments/tests.ts
+++ b/config/environments/tests.ts
@@ -18,15 +18,10 @@ const config: Config = {
 
   sessionTokenLen: 64,
   sessionCookieName: 'noratomo-session',
-  sessionPeriodDay: 7,
+  sessionPeriodDay: 1,
   sessionCookieOptions: () => {
-    const date = new Date(Date.now());
-    date.setDate(date.getDate() + config.sessionPeriodDay);
-
     return {
       domain: 'localhost',
-      expires: date,
-      maxAge: config.sessionPeriodDay * 86400,
       sameSite: 'strict',
       secure: false, // テスト用であるためfalse
       httpOnly: true,


### PR DESCRIPTION
- issue: close https://github.com/team-ful/noratomo/issues/95

## 🔧 修正点

- セッショントークンのcookie有効期限をセッション間に変更
- DBのセッショントークン保存を7日から1日に変更

## ✅ 自己チェック

- [x] 動作確認ができているか
- [x] 新しく追加したメソッドにユニットテストを追加しているか
- [x] 静的解析、テストは成功しているか
- [x] `Files changed`を自分で確認してミスがないか

## 📸 スクリーンショット（オプション）

## ⚠️ レビュー時に注意して欲しいこと（オプション）

## 🗣️ 補足など（オプション）
