### PR TITLE
Argon2がコンテナ内で落ちる問題を修正

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,8 @@ ENV NODE_ENV production
 RUN addgroup -g 1001 -S nodejs
 RUN adduser -S nextjs -u 1001
 
+RUN apk update && apk add clang gcc
+
 # You only need to copy next.config.js if you are NOT using the default configuration
 # COPY --from=builder /app/next.config.js ./
 COPY --from=builder /app/public ./public

--- a/src/user/createAccount.ts
+++ b/src/user/createAccount.ts
@@ -157,6 +157,15 @@ export class CreateAccountByPassword {
    * @returns {User} - ユーザ
    */
   public async create(db: DBOperator): Promise<User> {
+    let hashPW = '';
+    try {
+      hashPW = await argon2.hash(this.password);
+    } catch (e) {
+      if (e instanceof Error) {
+        throw new ApiError(500, e.message);
+      }
+    }
+
     const userID = await createUserPW(
       db,
       this.mail,
@@ -164,8 +173,6 @@ export class CreateAccountByPassword {
       this.gender,
       this.age
     );
-
-    const hashPW = await argon2.hash(this.password);
 
     const c: CertModel = {
       user_id: userID,


### PR DESCRIPTION
- issue:

## 🔧 修正点

PWのハッシュ化には[argon2 - npm](https://www.npmjs.com/package/argon2)をしようしている。しかし、argon2の計算はCで記述されており実行にはClang >= 3.3が必要である。

> You MUST have a node-gyp global install before proceeding with install, along with GCC >= 5 / Clang >= 3.3. On Windows, you must compile under Visual Studio 2015 or newer.

このPRでは、何故か落ちるargon2のためにGCCとClangをインストールするように変更した。

## ✅ 自己チェック

- [x] 動作確認ができているか
- [x] 新しく追加したメソッドにユニットテストを追加しているか
- [x] 静的解析、テストは成功しているか
- [x] `Files changed`を自分で確認してミスがないか

## 📸 スクリーンショット（オプション）

## ⚠️ レビュー時に注意して欲しいこと（オプション）

## 🗣️ 補足など（オプション）
